### PR TITLE
Add hybrid cache extension tests

### DIFF
--- a/src/NatsHybridCache/NatsHybridCache.csproj
+++ b/src/NatsHybridCache/NatsHybridCache.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>

--- a/test/IntegrationTests/IntegrationTests.csproj
+++ b/test/IntegrationTests/IntegrationTests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TestUtils\TestUtils.csproj" />
-    <ProjectReference Include="..\..\src\NatsDistributedCache\NatsDistributedCache.csproj" />
+    <ProjectReference Include="..\..\src\NatsHybridCache\NatsHybridCache.csproj" />
     <ProjectReference Include="..\..\util\NatsAppHost\NatsAppHost.csproj" />
   </ItemGroup>
 

--- a/test/TestUtils/TestUtils.csproj
+++ b/test/TestUtils/TestUtils.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageReference Include="NATS.Net" Version="2.6.0" />
     <PackageReference Include="xunit.v3.assert" Version="2.0.2" />
@@ -13,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NatsDistributedCache\NatsDistributedCache.csproj" />
+    <ProjectReference Include="..\..\src\NatsHybridCache\NatsHybridCache.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/Extensions/NatsHybridCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsHybridCacheExtensionsTests.cs
@@ -1,0 +1,137 @@
+using CodeCargo.Nats.HybridCache;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using NATS.Client.Core;
+
+namespace CodeCargo.Nats.DistributedCache.UnitTests.Extensions;
+
+public class NatsHybridCacheExtensionsTests
+{
+    private readonly Mock<INatsConnection> _mockNatsConnection = new();
+
+    [Fact]
+    public void AddNatsHybridCache_RegistersSerializerFactoryAsSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+
+        services.AddNatsHybridCache(options =>
+        {
+            options.BucketName = "cache";
+        });
+
+        var registration = services.FirstOrDefault(d => d.ServiceType == typeof(IHybridCacheSerializerFactory));
+        Assert.NotNull(registration);
+        Assert.Equal(ServiceLifetime.Singleton, registration!.Lifetime);
+    }
+
+    [Fact]
+    public void AddNatsHybridCache_ReplacesPreviouslyUserRegisteredServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        services.AddSingleton<IHybridCacheSerializerFactory>(new FakeHybridCacheSerializerFactory());
+
+        services.AddNatsHybridCache(options =>
+        {
+            options.BucketName = "cache";
+        });
+
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHybridCacheSerializerFactory>();
+
+        Assert.NotEqual(typeof(FakeHybridCacheSerializerFactory), factory.GetType());
+        Assert.Contains("NatsHybridCacheSerializerFactory", factory.GetType().Name);
+    }
+
+    [Fact]
+    public void AddNatsHybridCache_SetsCacheOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        const string expectedNamespace = "TestNamespace";
+
+        services.AddNatsHybridCache(options =>
+        {
+            options.BucketName = "cache";
+            options.CacheKeyPrefix = expectedNamespace;
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<NatsCacheOptions>>().Value;
+
+        Assert.Equal(expectedNamespace, options.CacheKeyPrefix);
+        Assert.Equal("cache", options.BucketName);
+    }
+
+    [Fact]
+    public void AddNatsHybridCache_UsesCacheOptionsAction()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        var wasInvoked = false;
+
+        services.AddNatsHybridCache(options =>
+        {
+            options.BucketName = "cache";
+            wasInvoked = true;
+        });
+
+        var sp = services.BuildServiceProvider();
+        _ = sp.GetRequiredService<IHybridCacheSerializerFactory>();
+
+        Assert.True(wasInvoked);
+    }
+
+    [Fact]
+    public void AddNatsHybridCache_AcceptsConnectionServiceKey_Parameter()
+    {
+        var services = new ServiceCollection();
+        var defaultConnection = new Mock<INatsConnection>().Object;
+        var keyedConnection = new Mock<INatsConnection>().Object;
+
+        services.AddSingleton(defaultConnection);
+        services.AddKeyedSingleton("my-key", keyedConnection);
+
+        services.AddNatsHybridCache(
+            options => { options.BucketName = "cache"; },
+            connectionServiceKey: "my-key");
+
+        var cacheReg = services.FirstOrDefault(d => d.ServiceType == typeof(IHybridCacheSerializerFactory));
+        Assert.NotNull(cacheReg);
+        Assert.Equal(ServiceLifetime.Singleton, cacheReg!.Lifetime);
+        Assert.Null(cacheReg.ImplementationType);
+        Assert.NotNull(cacheReg.ImplementationFactory);
+
+        var optionsReg = services.FirstOrDefault(d => d.ServiceType == typeof(IConfigureOptions<NatsCacheOptions>));
+        Assert.NotNull(optionsReg);
+    }
+
+    [Fact]
+    public void AddNatsHybridCacheSerializerFactory_AddsSerializerFactory()
+    {
+        var builderMock = new Mock<IHybridCacheBuilder>();
+        var registry = NatsOpts.Default.SerializerRegistry;
+
+        builderMock
+            .Setup(b => b.AddSerializerFactory(It.IsAny<IHybridCacheSerializerFactory>()))
+            .Returns(builderMock.Object)
+            .Verifiable();
+
+        var result = builderMock.Object.AddNatsHybridCacheSerializerFactory(registry);
+
+        builderMock.Verify(b => b.AddSerializerFactory(It.IsAny<IHybridCacheSerializerFactory>()), Times.Once);
+        Assert.Equal(builderMock.Object, result);
+    }
+
+    private class FakeHybridCacheSerializerFactory : IHybridCacheSerializerFactory
+    {
+        public bool TryCreateSerializer<T>(out IHybridCacheSerializer<T>? serializer)
+        {
+            serializer = null;
+            return false;
+        }
+    }
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NatsDistributedCache\NatsDistributedCache.csproj" />
+    <ProjectReference Include="..\..\src\NatsHybridCache\NatsHybridCache.csproj" />
     <ProjectReference Include="..\TestUtils\TestUtils.csproj" />
   </ItemGroup>
 

--- a/util/NatsAppHost/NatsAppHost.csproj
+++ b/util/NatsAppHost/NatsAppHost.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NatsDistributedCache\NatsDistributedCache.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\..\src\NatsHybridCache\NatsHybridCache.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/util/ReadmeExample/ReadmeExample.csproj
+++ b/util/ReadmeExample/ReadmeExample.csproj
@@ -8,12 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="9.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="9.4.0" />
     <PackageReference Include="NATS.Net" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\NatsDistributedCache\NatsDistributedCache.csproj" />
+    <ProjectReference Include="..\..\src\NatsHybridCache\NatsHybridCache.csproj" />
     <ProjectReference Include="..\NatsAppHost\NatsAppHost.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add unit tests for NatsHybridCacheExtensions
- point test and util projects at NatsHybridCache
- remove redundant Hybrid cache package references

## Testing
- `./dev/check-bom.sh`