### PR TITLE
Fix missing ConfigureAwait in async call

### DIFF
--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -243,7 +243,7 @@ public partial class NatsCache : IBufferDistributedCache
             try
             {
                 var kv = _natsConnection.CreateKeyValueStoreContext();
-                var store = await kv.GetStoreAsync(_bucketName);
+                var store = await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
                 LogConnected(_bucketName);
                 return store;
             }


### PR DESCRIPTION
## Summary
- ensure awaited NATS KV retrieval uses `ConfigureAwait(false)`

## Testing
- `dotnet --version` *(fails: command not found)*