### PR TITLE
Switch test utils to AddNatsHybridCache

### DIFF
--- a/test/TestUtils/NatsTestExtensions.cs
+++ b/test/TestUtils/NatsTestExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using NATS.Client.Core;
 using NATS.Client.Hosting;
+using CodeCargo.NatsHybridCache;
 
 namespace CodeCargo.NatsDistributedCache.TestUtils;
 
@@ -16,13 +17,12 @@ public static class NatsTestExtensions
 
     public static IServiceCollection AddHybridCacheTestClient(this IServiceCollection services)
     {
-        // Add HybridCache
-        var hybridCacheServices = services.AddHybridCache();
+        // Add the NATS hybrid cache with default options
+        services.AddNatsHybridCache(options =>
+        {
+            options.BucketName = "cache";
+        });
 
-        // Use NATS Serializer for HybridCache
-        var natsOpts = NatsOpts.Default;
-        hybridCacheServices.AddSerializerFactory(
-          natsOpts.SerializerRegistry.ToHybridCacheSerializerFactory());
         return services;
     }
 }


### PR DESCRIPTION
## Summary
- update `AddHybridCacheTestClient` to use `AddNatsHybridCache`

## Testing
- `dotnet` command unavailable; no tests run