### PR TITLE
Add README examples and NatsClient usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const string natsUrl = "nats://localhost:4222";
 var builder = Host.CreateDefaultBuilder(args);
 builder.ConfigureServices(services =>
 {
-    services.AddNats(configureOpts: options => options with { Url = natsUrl });
+    services.AddNatsClient(configureOpts: options => options with { Url = natsUrl });
 
     services.AddNatsDistributedCache(options =>
     {

--- a/util/ReadmeExample/DistributedCache.Example.cs
+++ b/util/ReadmeExample/DistributedCache.Example.cs
@@ -2,13 +2,12 @@ using CodeCargo.Nats.DistributedCache;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NATS.Client.Core;
-using NATS.Client.Hosting;
+using NATS.Extensions.Microsoft.DependencyInjection;
 using NATS.Client.KeyValueStore;
 using NATS.Net;
 
-// The abbreviated example put into the README.md
-// Based on Program.cs
-public static class Abbreviated
+// Example used in the README.md "Use `IDistributedCache` Directly" section
+public static class DistributedCacheExample
 {
     public static async Task Run(string[] args)
     {
@@ -23,20 +22,13 @@ public static class Abbreviated
         builder.ConfigureServices(services =>
         {
             // Add NATS client
-            services.AddNats(configureOpts: options => options with { Url = natsUrl });
+            services.AddNatsClient(natsBuilder => natsBuilder.ConfigureOptions(opts => opts with { Url = natsUrl }));
 
             // Add a NATS distributed cache
             services.AddNatsDistributedCache(options =>
             {
                 options.BucketName = "cache";
             });
-
-            // (Optional) Add HybridCache
-            var hybridCacheServices = services.AddHybridCache();
-
-            // (Optional) Use NATS Serializer for HybridCache
-            hybridCacheServices.AddSerializerFactory(
-                NatsOpts.Default.SerializerRegistry.ToHybridCacheSerializerFactory());
 
             // Add other services as needed
         });

--- a/util/ReadmeExample/HybridCache.Example.cs
+++ b/util/ReadmeExample/HybridCache.Example.cs
@@ -1,0 +1,50 @@
+using CodeCargo.Nats.HybridCacheExtensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NATS.Client.Core;
+using NATS.Extensions.Microsoft.DependencyInjection;
+using NATS.Client.KeyValueStore;
+using NATS.Net;
+
+// Example used in the README.md "Use with `HybridCache`" section
+public static class HybridCacheExample
+{
+    public static async Task Run(string[] args)
+    {
+        // Set the NATS URL, this normally comes from configuration
+        const string natsUrl = "nats://localhost:4222";
+
+        // Create a host builder for a Console application
+        // For a Web Application you can use WebApplication.CreateBuilder(args)
+        var builder = Host.CreateDefaultBuilder(args);
+
+        // Add services to the container
+        builder.ConfigureServices(services =>
+        {
+            // Add NATS client
+            services.AddNatsClient(natsBuilder => natsBuilder.ConfigureOptions(opts => opts with { Url = natsUrl }));
+
+            // Add a NATS HybridCache
+            services.AddNatsHybridCache(options =>
+            {
+                options.BucketName = "cache";
+            });
+
+            // Add other services as needed
+        });
+
+        // Build the host
+        var host = builder.Build();
+
+        // Ensure that the KV Store is created
+        var natsConnection = host.Services.GetRequiredService<INatsConnection>();
+        var kvContext = natsConnection.CreateKeyValueStoreContext();
+        await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache")
+        {
+            LimitMarkerTTL = TimeSpan.FromSeconds(1)
+        });
+
+        // Start the host
+        await host.RunAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- replace Abbreviated.cs with `DistributedCache.Example.cs` and `HybridCache.Example.cs`
- update README examples to use `AddNatsClient`

## Testing
- `dotnet build util/ReadmeExample/ReadmeExample.csproj`
- `dotnet test test/UnitTests/UnitTests.csproj`