### PR TITLE
CodeCargo: Add code-cargo/cargowall-action@v1.2.0 to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
     steps:
+    - name: CargoWall
+      uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
     - name: Checkout
       uses: actions/checkout@v6
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,13 @@ jobs:
     environment: nuget
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      actions: read
+      id-token: write
     steps:
+    - name: CargoWall
+      uses: code-cargo/cargowall-action@fc9644606d84536b4e59a30ad2802904f7b4ff22 # v1.2.0
     - uses: actions/checkout@v6
 
     - name: Setup dotnet


### PR DESCRIPTION
## Add code-cargo/cargowall-action

Adds `code-cargo/cargowall-action@v1.2.0` as the first step in each workflow job with the required permissions.

> SHA-pinned to `fc9644606d84536b4e59a30ad2802904f7b4ff22` (v1.2.0)

### Modified workflows
- `.github/workflows/publish.yml`
- `.github/workflows/build.yml`

### Permissions added per job
```yaml
permissions:
  contents: read
  actions: read
  id-token: write
```

---
Generated by [CodeCargo](https://codecargo.com)