### PR TITLE
#40 Inject TimeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache") { LimitMarker
 await host.RunAsync();
 ```
 
+## Controlling Expiration Timing
+
+Expiration is computed from a [`TimeProvider`](https://learn.microsoft.com/dotnet/api/system.timeprovider),
+defaulting to `TimeProvider.System`. Register a `TimeProvider` in DI to override the clock the cache uses —
+for example, to drive expiration deterministically in tests with
+[`FakeTimeProvider`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.time.testing.faketimeprovider):
+
+```csharp
+services.AddSingleton<TimeProvider>(new FakeTimeProvider());
+services.AddNatsDistributedCache(options => options.BucketName = "cache");
+```
+
 ## Additional Resources
 
 * [ASP.NET Core Hybrid Cache Documentation](https://learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?view=aspnetcore-10.0)

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -190,12 +190,7 @@ public partial class NatsCache : IBufferDistributedCache
                 "The sliding expiration value must be positive.");
         }
 
-        var absoluteExpiration = options.AbsoluteExpiration;
-        if (options.AbsoluteExpirationRelativeToNow.HasValue)
-        {
-            absoluteExpiration = _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value);
-        }
-
+        var absoluteExpiration = ResolveAbsoluteExpiration(options);
         if (!absoluteExpiration.HasValue)
         {
             return options.SlidingExpiration;
@@ -214,26 +209,23 @@ public partial class NatsCache : IBufferDistributedCache
             : ttl;
     }
 
-    internal CacheEntry CreateCacheEntry(byte[] value, DistributedCacheEntryOptions options)
-    {
-        var absoluteExpiration = options.AbsoluteExpiration;
-        if (options.AbsoluteExpirationRelativeToNow.HasValue)
-        {
-            absoluteExpiration = _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value);
-        }
-
-        var cacheEntry = new CacheEntry
+    internal CacheEntry CreateCacheEntry(byte[] value, DistributedCacheEntryOptions options) =>
+        new CacheEntry
         {
             Data = value,
-            AbsoluteExpiration = absoluteExpiration,
+            AbsoluteExpiration = ResolveAbsoluteExpiration(options),
             SlidingExpirationTicks = options.SlidingExpiration?.Ticks
         };
 
-        return cacheEntry;
-    }
-
     internal bool IsExpired(CacheEntry entry) =>
         entry.AbsoluteExpiration.HasValue && _timeProvider.GetUtcNow() > entry.AbsoluteExpiration.Value;
+
+    // Resolves the effective absolute expiration instant: a relative expiration (offset from the
+    // current clock) takes precedence over an explicit absolute expiration when both are set.
+    private DateTimeOffset? ResolveAbsoluteExpiration(DistributedCacheEntryOptions options) =>
+        options.AbsoluteExpirationRelativeToNow.HasValue
+            ? _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value)
+            : options.AbsoluteExpiration;
 
     private string GetEncodedKey(string key) =>
         string.IsNullOrEmpty(_keyPrefix)

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -47,13 +47,15 @@ public partial class NatsCache : IBufferDistributedCache
     private readonly string _keyPrefix;
     private readonly ILogger _logger;
     private readonly INatsConnection _natsConnection;
+    private readonly TimeProvider _timeProvider;
     private Lazy<Task<INatsKVStore>> _lazyKvStore;
 
     public NatsCache(
         IOptions<NatsCacheOptions> optionsAccessor,
         INatsConnection natsConnection,
         ILogger<NatsCache>? logger = null,
-        INatsCacheKeyEncoder? keyEncoder = null)
+        INatsCacheKeyEncoder? keyEncoder = null,
+        TimeProvider? timeProvider = null)
     {
         var options = optionsAccessor.Value;
         _bucketName = !string.IsNullOrWhiteSpace(options.BucketName)
@@ -66,6 +68,7 @@ public partial class NatsCache : IBufferDistributedCache
         _natsConnection = natsConnection;
         _logger = logger ?? NullLogger<NatsCache>.Instance;
         _keyEncoder = keyEncoder ?? new NatsCacheKeyEncoder();
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     /// <inheritdoc />
@@ -160,9 +163,9 @@ public partial class NatsCache : IBufferDistributedCache
         return false;
     }
 
-    private static TimeSpan? GetTtl(DistributedCacheEntryOptions options)
+    internal TimeSpan? GetTtl(DistributedCacheEntryOptions options)
     {
-        if (options.AbsoluteExpiration.HasValue && options.AbsoluteExpiration.Value <= DateTimeOffset.Now)
+        if (options.AbsoluteExpiration.HasValue && options.AbsoluteExpiration.Value <= _timeProvider.GetUtcNow())
         {
             throw new ArgumentOutOfRangeException(
                 nameof(DistributedCacheEntryOptions.AbsoluteExpiration),
@@ -190,7 +193,7 @@ public partial class NatsCache : IBufferDistributedCache
         var absoluteExpiration = options.AbsoluteExpiration;
         if (options.AbsoluteExpirationRelativeToNow.HasValue)
         {
-            absoluteExpiration = DateTimeOffset.Now.Add(options.AbsoluteExpirationRelativeToNow.Value);
+            absoluteExpiration = _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value);
         }
 
         if (!absoluteExpiration.HasValue)
@@ -198,7 +201,7 @@ public partial class NatsCache : IBufferDistributedCache
             return options.SlidingExpiration;
         }
 
-        var ttl = absoluteExpiration.Value - DateTimeOffset.Now;
+        var ttl = absoluteExpiration.Value - _timeProvider.GetUtcNow();
         if (ttl.TotalMilliseconds <= 0)
         {
             // Value is in the past, remove it
@@ -211,12 +214,12 @@ public partial class NatsCache : IBufferDistributedCache
             : ttl;
     }
 
-    private static CacheEntry CreateCacheEntry(byte[] value, DistributedCacheEntryOptions options)
+    internal CacheEntry CreateCacheEntry(byte[] value, DistributedCacheEntryOptions options)
     {
         var absoluteExpiration = options.AbsoluteExpiration;
         if (options.AbsoluteExpirationRelativeToNow.HasValue)
         {
-            absoluteExpiration = DateTimeOffset.Now.Add(options.AbsoluteExpirationRelativeToNow.Value);
+            absoluteExpiration = _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value);
         }
 
         var cacheEntry = new CacheEntry
@@ -228,6 +231,9 @@ public partial class NatsCache : IBufferDistributedCache
 
         return cacheEntry;
     }
+
+    internal bool IsExpired(CacheEntry entry) =>
+        entry.AbsoluteExpiration.HasValue && _timeProvider.GetUtcNow() > entry.AbsoluteExpiration.Value;
 
     private string GetEncodedKey(string key) =>
         string.IsNullOrEmpty(_keyPrefix)
@@ -277,7 +283,7 @@ public partial class NatsCache : IBufferDistributedCache
             }
 
             // Check absolute expiration
-            if (kvEntry.Value.AbsoluteExpiration != null && DateTimeOffset.Now > kvEntry.Value.AbsoluteExpiration)
+            if (IsExpired(kvEntry.Value))
             {
                 // NatsKVWrongLastRevisionException is caught below
                 var natsDeleteOpts = new NatsKVDeleteOpts { Revision = kvEntry.Revision };
@@ -313,7 +319,7 @@ public partial class NatsCache : IBufferDistributedCache
             // If we also have an absolute expiration, make sure we don't exceed it
             if (kvEntry.Value.AbsoluteExpiration != null)
             {
-                var remainingTime = kvEntry.Value.AbsoluteExpiration.Value - DateTimeOffset.Now;
+                var remainingTime = kvEntry.Value.AbsoluteExpiration.Value - _timeProvider.GetUtcNow();
 
                 // Use the minimum of sliding window or remaining absolute time
                 if (remainingTime > TimeSpan.Zero && remainingTime < ttl)

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -217,8 +217,11 @@ public partial class NatsCache : IBufferDistributedCache
             SlidingExpirationTicks = options.SlidingExpiration?.Ticks
         };
 
-    internal bool IsExpired(CacheEntry entry) =>
-        entry.AbsoluteExpiration.HasValue && _timeProvider.GetUtcNow() > entry.AbsoluteExpiration.Value;
+    // An entry is absolutely expired once the clock reaches its absolute expiration instant. The
+    // boundary is inclusive (>=) to match GetTtl, which treats an absolute expiration at "now" as
+    // already elapsed. Sliding expiration is enforced separately via the NATS entry TTL.
+    internal bool IsAbsolutelyExpired(CacheEntry entry) =>
+        entry.AbsoluteExpiration.HasValue && _timeProvider.GetUtcNow() >= entry.AbsoluteExpiration.Value;
 
     // Resolves the effective absolute expiration instant: a relative expiration (offset from the
     // current clock) takes precedence over an explicit absolute expiration when both are set.
@@ -275,7 +278,7 @@ public partial class NatsCache : IBufferDistributedCache
             }
 
             // Check absolute expiration
-            if (IsExpired(kvEntry.Value))
+            if (IsAbsolutelyExpired(kvEntry.Value))
             {
                 // NatsKVWrongLastRevisionException is caught below
                 var natsDeleteOpts = new NatsKVDeleteOpts { Revision = kvEntry.Revision };

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -47,15 +47,13 @@ public partial class NatsCache : IBufferDistributedCache
     private readonly string _keyPrefix;
     private readonly ILogger _logger;
     private readonly INatsConnection _natsConnection;
-    private readonly TimeProvider _timeProvider;
     private Lazy<Task<INatsKVStore>> _lazyKvStore;
 
     public NatsCache(
         IOptions<NatsCacheOptions> optionsAccessor,
         INatsConnection natsConnection,
         ILogger<NatsCache>? logger = null,
-        INatsCacheKeyEncoder? keyEncoder = null,
-        TimeProvider? timeProvider = null)
+        INatsCacheKeyEncoder? keyEncoder = null)
     {
         var options = optionsAccessor.Value;
         _bucketName = !string.IsNullOrWhiteSpace(options.BucketName)
@@ -68,8 +66,12 @@ public partial class NatsCache : IBufferDistributedCache
         _natsConnection = natsConnection;
         _logger = logger ?? NullLogger<NatsCache>.Instance;
         _keyEncoder = keyEncoder ?? new NatsCacheKeyEncoder();
-        _timeProvider = timeProvider ?? TimeProvider.System;
     }
+
+    // The clock used for all expiration calculations. Defaults to TimeProvider.System; the DI
+    // registration overrides it with a TimeProvider resolved from the container when one is present
+    // (for example, FakeTimeProvider in tests). Injected via init to keep the constructor unchanged.
+    internal TimeProvider TimeProvider { get; init; } = TimeProvider.System;
 
     /// <inheritdoc />
     public void Set(string key, byte[] value, DistributedCacheEntryOptions options) =>
@@ -165,7 +167,7 @@ public partial class NatsCache : IBufferDistributedCache
 
     internal TimeSpan? GetTtl(DistributedCacheEntryOptions options)
     {
-        if (options.AbsoluteExpiration.HasValue && options.AbsoluteExpiration.Value <= _timeProvider.GetUtcNow())
+        if (options.AbsoluteExpiration.HasValue && options.AbsoluteExpiration.Value <= TimeProvider.GetUtcNow())
         {
             throw new ArgumentOutOfRangeException(
                 nameof(DistributedCacheEntryOptions.AbsoluteExpiration),
@@ -196,7 +198,7 @@ public partial class NatsCache : IBufferDistributedCache
             return options.SlidingExpiration;
         }
 
-        var ttl = absoluteExpiration.Value - _timeProvider.GetUtcNow();
+        var ttl = absoluteExpiration.Value - TimeProvider.GetUtcNow();
         if (ttl.TotalMilliseconds <= 0)
         {
             // Value is in the past, remove it
@@ -221,13 +223,13 @@ public partial class NatsCache : IBufferDistributedCache
     // boundary is inclusive (>=) to match GetTtl, which treats an absolute expiration at "now" as
     // already elapsed. Sliding expiration is enforced separately via the NATS entry TTL.
     internal bool IsAbsolutelyExpired(CacheEntry entry) =>
-        entry.AbsoluteExpiration.HasValue && _timeProvider.GetUtcNow() >= entry.AbsoluteExpiration.Value;
+        entry.AbsoluteExpiration.HasValue && TimeProvider.GetUtcNow() >= entry.AbsoluteExpiration.Value;
 
     // Resolves the effective absolute expiration instant: a relative expiration (offset from the
     // current clock) takes precedence over an explicit absolute expiration when both are set.
     private DateTimeOffset? ResolveAbsoluteExpiration(DistributedCacheEntryOptions options) =>
         options.AbsoluteExpirationRelativeToNow.HasValue
-            ? _timeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value)
+            ? TimeProvider.GetUtcNow().Add(options.AbsoluteExpirationRelativeToNow.Value)
             : options.AbsoluteExpiration;
 
     private string GetEncodedKey(string key) =>
@@ -314,7 +316,7 @@ public partial class NatsCache : IBufferDistributedCache
             // If we also have an absolute expiration, make sure we don't exceed it
             if (kvEntry.Value.AbsoluteExpiration != null)
             {
-                var remainingTime = kvEntry.Value.AbsoluteExpiration.Value - _timeProvider.GetUtcNow();
+                var remainingTime = kvEntry.Value.AbsoluteExpiration.Value - TimeProvider.GetUtcNow();
 
                 // Use the minimum of sliding window or remaining absolute time
                 if (remainingTime > TimeSpan.Zero && remainingTime < ttl)

--- a/src/NatsDistributedCache/NatsDistributedCache.csproj
+++ b/src/NatsDistributedCache/NatsDistributedCache.csproj
@@ -39,4 +39,14 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <!-- Expose internals to the unit tests for white-box time/expiration testing.
+       A signed (strong-named) assembly cannot grant InternalsVisibleTo to the unsigned UnitTests
+       assembly, so this is gated to unsigned builds. That covers every build that actually compiles
+       the tests: CI (build.yml) and local dev never write the .snk, and the signed publish job
+       (publish.yml) runs `dotnet pack`, which does not build test projects. Caveat: dropping the
+       .snk into keys/ locally flips the build to signed and will break the UnitTests compile. -->
+  <ItemGroup Condition="'$(SignAssembly)' != 'true'">
+    <InternalsVisibleTo Include="UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
+++ b/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
@@ -37,12 +37,10 @@ public static class NatsDistributedCacheExtensions
             var keyEncoder = sp.GetService<INatsCacheKeyEncoder>();
             var timeProvider = sp.GetService<TimeProvider>();
 
-            return new NatsCache(
-                optionsAccessor,
-                natsConnection,
-                logger: logger,
-                keyEncoder: keyEncoder,
-                timeProvider: timeProvider);
+            return new NatsCache(optionsAccessor, natsConnection, logger: logger, keyEncoder: keyEncoder)
+            {
+                TimeProvider = timeProvider ?? TimeProvider.System,
+            };
         });
 
         return services;

--- a/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
+++ b/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
@@ -35,8 +35,14 @@ public static class NatsDistributedCacheExtensions
                 : sp.GetRequiredKeyedService<INatsConnection>(connectionServiceKey);
             var logger = sp.GetService<ILogger<NatsCache>>();
             var keyEncoder = sp.GetService<INatsCacheKeyEncoder>();
+            var timeProvider = sp.GetService<TimeProvider>();
 
-            return new NatsCache(optionsAccessor, natsConnection, logger: logger, keyEncoder: keyEncoder);
+            return new NatsCache(
+                optionsAccessor,
+                natsConnection,
+                logger: logger,
+                keyEncoder: keyEncoder,
+                timeProvider: timeProvider);
         });
 
         return services;

--- a/test/UnitTests/Cache/TimeExpirationAsyncUnitTests.cs
+++ b/test/UnitTests/Cache/TimeExpirationAsyncUnitTests.cs
@@ -11,7 +11,7 @@ public class TimeExpirationAsyncUnitTests : TestBase
         var key = MethodKey();
         var value = new byte[1];
 
-        var expected = DateTimeOffset.Now - TimeSpan.FromMinutes(1);
+        var expected = TimeProvider.GetUtcNow() - TimeSpan.FromMinutes(1);
         await ExceptionAssert.ThrowsArgumentOutOfRangeAsync(
             async () =>
             {

--- a/test/UnitTests/Cache/TimeExpirationUnitTests.cs
+++ b/test/UnitTests/Cache/TimeExpirationUnitTests.cs
@@ -11,7 +11,7 @@ public class TimeExpirationUnitTests : TestBase
         var key = MethodKey();
         var value = new byte[1];
 
-        var expected = DateTimeOffset.Now - TimeSpan.FromMinutes(1);
+        var expected = TimeProvider.GetUtcNow() - TimeSpan.FromMinutes(1);
         ExceptionAssert.ThrowsArgumentOutOfRange(
             () =>
             {

--- a/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
+++ b/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
@@ -15,11 +15,24 @@ public class TimeProviderExpirationUnitTests : TestBase
             new byte[1],
             new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30)));
 
-        Assert.False(Cache.IsExpired(entry));
+        Assert.False(Cache.IsAbsolutelyExpired(entry));
 
         TimeProvider.Advance(TimeSpan.FromSeconds(31));
 
-        Assert.True(Cache.IsExpired(entry));
+        Assert.True(Cache.IsAbsolutelyExpired(entry));
+    }
+
+    [Fact]
+    public void AbsoluteExpirationIsExpiredAtExactInstant()
+    {
+        var entry = Cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30)));
+
+        // Advance to exactly the absolute expiration instant: the boundary is inclusive.
+        TimeProvider.Advance(TimeSpan.FromSeconds(30));
+
+        Assert.True(Cache.IsAbsolutelyExpired(entry));
     }
 
     [Fact]
@@ -32,7 +45,7 @@ public class TimeProviderExpirationUnitTests : TestBase
         TimeProvider.Advance(TimeSpan.FromHours(1));
 
         // Absolute expiration only applies to entries with an absolute expiration set.
-        Assert.False(Cache.IsExpired(entry));
+        Assert.False(Cache.IsAbsolutelyExpired(entry));
     }
 
     [Fact]

--- a/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
+++ b/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace CodeCargo.Nats.DistributedCache.UnitTests.Cache;
+
+/// <summary>
+/// Verifies that expiration logic reads the clock from the injected <see cref="System.TimeProvider"/>,
+/// enabling deterministic, instant time-expiration tests without real delays.
+/// </summary>
+public class TimeProviderExpirationUnitTests : TestBase
+{
+    [Fact]
+    public void AbsoluteExpirationExpiresWhenTimeAdvances()
+    {
+        var entry = Cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30)));
+
+        Assert.False(Cache.IsExpired(entry));
+
+        TimeProvider.Advance(TimeSpan.FromSeconds(31));
+
+        Assert.True(Cache.IsExpired(entry));
+    }
+
+    [Fact]
+    public void SlidingOnlyEntryIsNeverAbsolutelyExpired()
+    {
+        var entry = Cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromSeconds(30)));
+
+        TimeProvider.Advance(TimeSpan.FromHours(1));
+
+        // Absolute expiration only applies to entries with an absolute expiration set.
+        Assert.False(Cache.IsExpired(entry));
+    }
+
+    [Fact]
+    public void CreateCacheEntryComputesAbsoluteExpirationFromProviderTime()
+    {
+        var entry = Cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5)));
+
+        Assert.Equal(TimeProvider.GetUtcNow().AddMinutes(5), entry.AbsoluteExpiration);
+        Assert.Null(entry.SlidingExpirationTicks);
+    }
+
+    [Fact]
+    public void GetTtlComputesRelativeExpirationFromProviderTime()
+    {
+        var ttl = Cache.GetTtl(new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5)));
+
+        Assert.Equal(TimeSpan.FromMinutes(5), ttl);
+    }
+
+    [Fact]
+    public void GetTtlComputesAbsoluteExpirationFromProviderTime()
+    {
+        var absolute = TimeProvider.GetUtcNow().AddMinutes(10);
+
+        var ttl = Cache.GetTtl(new DistributedCacheEntryOptions().SetAbsoluteExpiration(absolute));
+
+        Assert.Equal(TimeSpan.FromMinutes(10), ttl);
+    }
+
+    [Fact]
+    public void GetTtlReturnsSlidingExpirationWhenNoAbsolute()
+    {
+        var ttl = Cache.GetTtl(new DistributedCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(3)));
+
+        Assert.Equal(TimeSpan.FromMinutes(3), ttl);
+    }
+
+    [Fact]
+    public void GetTtlReturnsMinimumOfSlidingAndAbsolute()
+    {
+        var ttl = Cache.GetTtl(new DistributedCacheEntryOptions()
+            .SetSlidingExpiration(TimeSpan.FromMinutes(2))
+            .SetAbsoluteExpiration(TimeSpan.FromMinutes(10)));
+
+        Assert.Equal(TimeSpan.FromMinutes(2), ttl);
+    }
+}

--- a/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
+++ b/test/UnitTests/Cache/TimeProviderExpirationUnitTests.cs
@@ -60,8 +60,9 @@ public class TimeProviderExpirationUnitTests : TestBase
     }
 
     [Fact]
-    public void GetTtlComputesRelativeExpirationFromProviderTime()
+    public void GetTtlReturnsConfiguredRelativeExpiration()
     {
+        // A relative expiration yields a TTL equal to the configured duration, independent of the clock.
         var ttl = Cache.GetTtl(new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5)));
 
         Assert.Equal(TimeSpan.FromMinutes(5), ttl);

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -143,14 +143,14 @@ public class CacheServiceExtensionsUnitTests
         services.AddNatsDistributedCache(options => options.BucketName = "cache");
 
         var cache = (NatsCache)services.BuildServiceProvider().GetRequiredService<IDistributedCache>();
+
+        // Act - the expiration is computed from the registered (frozen) provider's clock
         var entry = cache.CreateCacheEntry(
             new byte[1],
-            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30)));
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5)));
 
-        // Act / Assert - advancing the registered provider expires the entry, proving it is wired in
-        Assert.False(cache.IsExpired(entry));
-        timeProvider.Advance(TimeSpan.FromSeconds(31));
-        Assert.True(cache.IsExpired(entry));
+        // Assert - matches the registered fake clock, not the real system clock, proving it is wired in
+        Assert.Equal(timeProvider.GetUtcNow().AddMinutes(5), entry.AbsoluteExpiration);
     }
 
     [Fact]

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using NATS.Client.Core;
 
@@ -129,6 +130,49 @@ public class CacheServiceExtensionsUnitTests
         var optionsRegistration = services.FirstOrDefault(d =>
             d.ServiceType == typeof(IConfigureOptions<NatsCacheOptions>));
         Assert.NotNull(optionsRegistration);
+    }
+
+    [Fact]
+    public void AddNatsCache_UsesRegisteredTimeProvider()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        var timeProvider = new FakeTimeProvider();
+        services.AddSingleton<TimeProvider>(timeProvider);
+        services.AddNatsDistributedCache(options => options.BucketName = "cache");
+
+        var cache = (NatsCache)services.BuildServiceProvider().GetRequiredService<IDistributedCache>();
+        var entry = cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromSeconds(30)));
+
+        // Act / Assert - advancing the registered provider expires the entry, proving it is wired in
+        Assert.False(cache.IsExpired(entry));
+        timeProvider.Advance(TimeSpan.FromSeconds(31));
+        Assert.True(cache.IsExpired(entry));
+    }
+
+    [Fact]
+    public void AddNatsCache_DefaultsToSystemTimeProviderWhenNoneRegistered()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        services.AddNatsDistributedCache(options => options.BucketName = "cache");
+
+        var cache = (NatsCache)services.BuildServiceProvider().GetRequiredService<IDistributedCache>();
+
+        // Act - with no registered TimeProvider the cache must fall back to TimeProvider.System (real UTC clock)
+        var before = DateTimeOffset.UtcNow;
+        var entry = cache.CreateCacheEntry(
+            new byte[1],
+            new DistributedCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(5)));
+        var after = DateTimeOffset.UtcNow;
+
+        // Assert - the absolute expiration is derived from the system clock, proving the default is wired in
+        Assert.NotNull(entry.AbsoluteExpiration);
+        Assert.InRange(entry.AbsoluteExpiration!.Value, before.AddMinutes(5), after.AddMinutes(5));
     }
 
     [Fact]

--- a/test/UnitTests/TestBase.cs
+++ b/test/UnitTests/TestBase.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using NATS.Client.Core;
 
@@ -16,15 +16,22 @@ public abstract class TestBase
         mockNatsConnection.SetupGet(m => m.Opts).Returns(opts);
         var connection = new NatsConnection(opts);
         mockNatsConnection.SetupGet(m => m.Connection).Returns(connection);
+        TimeProvider = new FakeTimeProvider();
         Cache = new NatsCache(
             Options.Create(new NatsCacheOptions { BucketName = "cache" }),
-            mockNatsConnection.Object);
+            mockNatsConnection.Object,
+            timeProvider: TimeProvider);
     }
+
+    /// <summary>
+    /// Gets the fake time provider driving the cache's clock
+    /// </summary>
+    protected FakeTimeProvider TimeProvider { get; }
 
     /// <summary>
     /// Gets the cache
     /// </summary>
-    protected IDistributedCache Cache { get; }
+    protected NatsCache Cache { get; }
 
     /// <summary>
     /// Gets the key for the current test method

--- a/test/UnitTests/TestBase.cs
+++ b/test/UnitTests/TestBase.cs
@@ -19,8 +19,10 @@ public abstract class TestBase
         TimeProvider = new FakeTimeProvider();
         Cache = new NatsCache(
             Options.Create(new NatsCacheOptions { BucketName = "cache" }),
-            mockNatsConnection.Object,
-            timeProvider: TimeProvider);
+            mockNatsConnection.Object)
+        {
+            TimeProvider = TimeProvider,
+        };
     }
 
     /// <summary>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/test/UnitTests/packages.linux-arm64.lock.json
+++ b/test/UnitTests/packages.linux-arm64.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -434,6 +440,12 @@
       }
     },
     "net8.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",

--- a/test/UnitTests/packages.linux-x64.lock.json
+++ b/test/UnitTests/packages.linux-x64.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -434,6 +440,12 @@
       }
     },
     "net8.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",

--- a/test/UnitTests/packages.osx-arm64.lock.json
+++ b/test/UnitTests/packages.osx-arm64.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -434,6 +440,12 @@
       }
     },
     "net8.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",

--- a/test/UnitTests/packages.win-x64.lock.json
+++ b/test/UnitTests/packages.win-x64.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -434,6 +440,12 @@
       }
     },
     "net8.0": {
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.1.0, )",
+        "resolved": "10.1.0",
+        "contentHash": "wH/CohN2yvYlpyPptNwWVZxlIQ8CkFvcv1eOEZTi/y8FhqVeISLbrraaW0qvVtXRKEeO0EyapNCZzj4HtdRGRw=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",


### PR DESCRIPTION
Closes #40

## Problem

`NatsCache` used `DateTimeOffset.Now` throughout its expiration logic (TTL computation, entry creation, absolute-expiration checks, sliding-window updates). That relies on the local wall clock and makes expiration behavior impossible to unit-test without real delays.

## Change

Route every clock read through an injected `TimeProvider` (default `TimeProvider.System`), resolved from DI. This is the .NET 8+ idiom and enables deterministic, instant expiration unit tests via `FakeTimeProvider`.

### Library (`src/NatsDistributedCache`)
- **`NatsCache.cs`**: replaced all `DateTimeOffset.Now` usages with `TimeProvider.GetUtcNow()`. The clock is exposed as an `internal` `init`-only `TimeProvider` property (default `TimeProvider.System`) rather than a constructor parameter, so **the public constructor is unchanged and there is no ABI break**. The absolute-expiration read check was extracted into `IsAbsolutelyExpired`, and the shared relative-vs-absolute resolution into `ResolveAbsoluteExpiration`.
- **`NatsDistributedCacheExtensions.cs`**: the DI registration resolves an optional `TimeProvider` via `sp.GetService<TimeProvider>()` and sets the property, falling back to `TimeProvider.System` when none is registered.
- **`README.md`**: documents overriding the clock by registering a `TimeProvider` in DI.

Switching from local-time `DateTimeOffset.Now` to UTC `GetUtcNow()` is behavior-preserving: every use is either an instant comparison or a duration, and `DateTimeOffset` operations are offset-aware. The one deliberate behavior change is that `IsAbsolutelyExpired` uses an inclusive `>=` boundary, matching `GetTtl` (which already treats an absolute expiration at "now" as elapsed) and BCL `MemoryCache`.

### Tests (`test/UnitTests`)
- Added the `Microsoft.Extensions.TimeProvider.Testing` package and regenerated the RID lock files.
- `TestBase` injects a `FakeTimeProvider` (exposed as a property) via the init property and exposes the concrete `NatsCache`.
- The existing absolute-expiration validation tests now drive time from `TimeProvider.GetUtcNow()`.
- New `TimeProviderExpirationUnitTests`: instant, no-delay tests for TTL computation, `CreateCacheEntry`, and absolute expiration flipping with `FakeTimeProvider.Advance` (including the exact-boundary case).
- New DI tests proving a registered `TimeProvider` is used, and that resolution falls back to `TimeProvider.System` (verified against the real UTC clock) when none is registered.

The integration time-expiration tests (`TimeExpirationTests`/`TimeExpirationAsyncTests`) are intentionally left with real delays — they exercise NATS's server-side TTL, whose clock a `FakeTimeProvider` can't drive.

## Acceptance criteria
- ✅ No `DateTimeOffset.Now` remains in the library.
- ✅ Time-expiration unit tests drive time with `FakeTimeProvider` (no real delays).
- ✅ DI wiring resolves an optional `TimeProvider`, defaulting to `TimeProvider.System`.

## Note on API surface
Injecting via the `internal` init property (instead of a constructor parameter) keeps the change **purely additive** — consumers compiled against 0.3.0 keep working without recompiling. The idiomatic way to override the clock is to register a `TimeProvider` in DI; consumers resolve `IDistributedCache`, so no public surface on the concrete `NatsCache` type is required.

## Verification
- `dotnet build -p TreatWarningsAsErrors=true` → 0 warnings (net8.0 + net10.0); the public constructor is byte-identical to `main`.
- `dotnet test test/UnitTests` → 46/46 passing on both frameworks.
- NuGet lock files regenerated and confirmed in sync (CI drift check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
