### PR TITLE
#42 validate options

### DIFF
--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -45,7 +45,7 @@ public partial class NatsCache : IBufferDistributedCache
         var options = optionsAccessor.Value;
         _bucketName = !string.IsNullOrWhiteSpace(options.BucketName)
             ? options.BucketName
-            : throw new NullReferenceException("BucketName must be set");
+            : throw new ArgumentException(NatsCacheOptions.BucketNameRequiredMessage, nameof(optionsAccessor));
         _keyPrefix = string.IsNullOrEmpty(options.CacheKeyPrefix)
             ? string.Empty
             : options.CacheKeyPrefix.TrimEnd('.');
@@ -328,9 +328,9 @@ public partial class NatsCache : IBufferDistributedCache
     }
 
     private async Task RemoveAsync(
-            string key,
-            NatsKVDeleteOpts? natsKvDeleteOpts = null,
-            CancellationToken token = default)
+        string key,
+        NatsKVDeleteOpts? natsKvDeleteOpts = null,
+        CancellationToken token = default)
     {
         var kvStore = await GetKvStore().ConfigureAwait(false);
         await kvStore.DeleteAsync(GetEncodedKey(key), natsKvDeleteOpts, cancellationToken: token)

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -45,7 +45,7 @@ public partial class NatsCache : IBufferDistributedCache
         var options = optionsAccessor.Value;
         _bucketName = !string.IsNullOrWhiteSpace(options.BucketName)
             ? options.BucketName
-            : throw new ArgumentException(NatsCacheOptions.BucketNameRequiredMessage, nameof(optionsAccessor));
+            : throw new ArgumentException(NatsCacheOptions.BucketNameRequiredMessage, nameof(NatsCacheOptions.BucketName));
         _keyPrefix = string.IsNullOrEmpty(options.CacheKeyPrefix)
             ? string.Empty
             : options.CacheKeyPrefix.TrimEnd('.');

--- a/src/NatsDistributedCache/NatsCacheOptions.cs
+++ b/src/NatsDistributedCache/NatsCacheOptions.cs
@@ -7,6 +7,10 @@ namespace CodeCargo.Nats.DistributedCache
     /// </summary>
     public class NatsCacheOptions : IOptions<NatsCacheOptions>
     {
+        // Shared by the startup options validator (AddNatsDistributedCache) and the NatsCache
+        // constructor guard so both validation paths report an identical message.
+        internal const string BucketNameRequiredMessage = "BucketName must be set";
+
         /// <summary>
         /// The NATS bucket name to use for the distributed cache.
         /// </summary>

--- a/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
+++ b/src/NatsDistributedCache/NatsDistributedCacheExtensions.cs
@@ -25,8 +25,10 @@ public static class NatsDistributedCacheExtensions
         Action<NatsCacheOptions> configureOptions,
         object? connectionServiceKey = null)
     {
-        services.AddOptions();
-        services.Configure(configureOptions);
+        services.AddOptions<NatsCacheOptions>()
+            .Configure(configureOptions)
+            .Validate(o => !string.IsNullOrWhiteSpace(o.BucketName), NatsCacheOptions.BucketNameRequiredMessage)
+            .ValidateOnStart();
         services.AddSingleton<IDistributedCache>(sp =>
         {
             var optionsAccessor = sp.GetRequiredService<IOptions<NatsCacheOptions>>();

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -186,6 +186,55 @@ public class CacheServiceExtensionsUnitTests
         Assert.Same(services, result);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void AddNatsCache_MissingBucketName_FailsValidationOnStart(string? bucketName)
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        services.AddNatsDistributedCache(options => options.BucketName = bucketName);
+        var validator = services.BuildServiceProvider().GetRequiredService<IStartupValidator>();
+
+        // Act - ValidateOnStart runs this at host startup; invoke it directly to prove it fails fast
+        var exception = Assert.Throws<OptionsValidationException>(() => validator.Validate());
+
+        // Assert - descriptive failure, not a NullReferenceException
+        Assert.Contains("BucketName must be set", exception.Message);
+    }
+
+    [Fact]
+    public void AddNatsCache_ValidBucketName_PassesValidationOnStart()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        services.AddNatsDistributedCache(options => options.BucketName = "cache");
+        var validator = services.BuildServiceProvider().GetRequiredService<IStartupValidator>();
+
+        // Act + Assert - a valid bucket name passes startup validation without throwing
+        validator.Validate();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void NatsCache_DirectConstruction_MissingBucketName_ThrowsArgumentException(string? bucketName)
+    {
+        // Arrange - direct construction bypasses the DI options validation pipeline
+        var options = Options.Create(new NatsCacheOptions { BucketName = bucketName });
+
+        // Act - the constructor guard fails fast with a clear ArgumentException, not a NullReferenceException
+        var exception = Assert.Throws<ArgumentException>(
+            () => new NatsCache(options, _mockNatsConnection.Object));
+
+        // Assert
+        Assert.Contains("BucketName must be set", exception.Message);
+    }
+
     [Fact]
     public void ToHybridCacheSerializerFactory_CreatesWorkingFactory()
     {

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -231,8 +231,9 @@ public class CacheServiceExtensionsUnitTests
         var exception = Assert.Throws<ArgumentException>(
             () => new NatsCache(options, _mockNatsConnection.Object));
 
-        // Assert
+        // Assert - message and paramName point at the offending config value, not the accessor
         Assert.Contains("BucketName must be set", exception.Message);
+        Assert.Equal(nameof(NatsCacheOptions.BucketName), exception.ParamName);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #42

## Problem

A missing or whitespace `BucketName` threw a `NullReferenceException` from the `NatsCache` constructor. That surfaced as a confusing error at first cache use rather than a clear configuration failure at startup.

## Change

Validate `NatsCacheOptions` through the options pattern so a bad `BucketName` fails fast, and replace the `NullReferenceException` with clear, typed exceptions.

### Library (`src/NatsDistributedCache`)
- **`NatsDistributedCacheExtensions.cs`**: `AddNatsDistributedCache` now registers `AddOptions<NatsCacheOptions>().Configure(...).Validate(o => !string.IsNullOrWhiteSpace(o.BucketName), ...).ValidateOnStart()`. With the Generic Host, an empty/whitespace `BucketName` fails at **startup** with a descriptive `OptionsValidationException`. Even without host startup validation, resolving the cache reads `IOptions.Value`, which runs the same validation *before* the constructor is reached. `AddNatsHybridCache` inherits this automatically (it delegates to `AddNatsDistributedCache`).
- **`NatsCache.cs`**: removed the `NullReferenceException` throw. The constructor keeps a guard that now throws `ArgumentException` — this is the only backstop for the direct `new NatsCache(...)` path, which bypasses the options-validation pipeline (`NatsCacheOptions` is its own `IOptions<>`, so a raw instance skips `.Validate()`).
- **`NatsCacheOptions.cs`**: the failure message lives in a single shared `internal const` referenced by both the DI validator and the constructor guard, so the two paths can't drift.

### Tests (`test/UnitTests`)
- `AddNatsCache_MissingBucketName_FailsValidationOnStart` — null/empty/whitespace fail fast via `IStartupValidator.Validate()` (the mechanism the host invokes), with the descriptive message.
- `AddNatsCache_ValidBucketName_PassesValidationOnStart` — a valid bucket name passes startup validation.
- `NatsCache_DirectConstruction_MissingBucketName_ThrowsArgumentException` — the direct-construction path throws `ArgumentException`, not `NullReferenceException`.

## Acceptance criteria
- ✅ Empty/whitespace `BucketName` fails fast at startup with a descriptive `OptionsValidationException`.
- ✅ No `NullReferenceException` path remains.

## Verification
- `dotnet test test/UnitTests` → 69/69 passing on net8.0 + net10.0.
- `dotnet build -p:TreatWarningsAsErrors=true` → 0 warnings (net8.0 + net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
