### PR TITLE
#38 add bucket auto creation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ A .NET 8+ library (tested on .NET 8 and .NET 10) for using NATS with `HybridCach
   [automatic bucket creation](#automatic-bucket-creation) (`options.CreateBucketIfNotExists = true`), or
   pre-create the bucket yourself:
     ```csharp
+    using NATS.Client.KeyValueStore;
+    using NATS.Net;
+
     // assuming an INatsConnection natsConnection
     var kvContext = natsConnection.CreateKeyValueStoreContext();
     await kvContext.CreateOrUpdateStoreAsync(

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ services.AddNatsDistributedCache(options =>
 });
 ```
 
-To customize storage, replication, or size limits, use `ConfigureBucket`. `NatsKVConfig` is an
+To customize storage, replication, or size limits, use `ConfigureBucketOnCreate`. `NatsKVConfig` is an
 immutable record, so return a modified copy with a `with` expression:
 
 ```csharp
@@ -142,7 +142,7 @@ services.AddNatsDistributedCache(options =>
 {
     options.BucketName = "cache";
     options.CreateBucketIfNotExists = true;
-    options.ConfigureBucket = config => config with
+    options.ConfigureBucketOnCreate = config => config with
     {
         Storage = NatsKVStorageType.File,
         NumberOfReplicas = 3,
@@ -153,10 +153,10 @@ services.AddNatsDistributedCache(options =>
 Notes:
 
 - Only a missing bucket is created; an existing bucket is used as-is and never modified, so
-  operator-managed settings are preserved. `ConfigureBucket` therefore only applies when the bucket is
+  operator-managed settings are preserved. `ConfigureBucketOnCreate` therefore only applies when the bucket is
   first created.
 - Creating a bucket requires JetStream stream-management permissions.
-- Overriding `History` (away from `1`) or clearing `LimitMarkerTTL` in `ConfigureBucket` disables
+- Overriding `History` (away from `1`) or clearing `LimitMarkerTTL` in `ConfigureBucketOnCreate` disables
   reliable per-key TTL.
 
 ## Controlling Expiration Timing

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A .NET 8+ library (tested on .NET 8 and .NET 10) for using NATS with `HybridCach
     ```csharp
     // assuming an INatsConnection natsConnection
     var kvContext = natsConnection.CreateKeyValueStoreContext();
-    await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1) });
+    await kvContext.CreateOrUpdateStoreAsync(
+        new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1), History = 1 });
     ```
 
 ## Use with `HybridCache`
@@ -117,7 +118,7 @@ await host.RunAsync();
 ## Automatic bucket creation
 
 By default the KV bucket must already exist. Set `CreateBucketIfNotExists = true` to have the cache
-create it (via `CreateOrUpdateStoreAsync`) on first use, with the settings per-key TTL requires —
+create it on first use if it is missing, with the settings per-key TTL requires —
 `History = 1` and a non-zero `LimitMarkerTTL`:
 
 ```csharp
@@ -148,9 +149,10 @@ services.AddNatsDistributedCache(options =>
 
 Notes:
 
-- Creating or updating a bucket requires JetStream stream-management permissions.
-- Because `CreateOrUpdateStoreAsync` is used, an existing bucket is also updated to match the resolved
-  config; immutable properties (for example `Storage`) can't be changed on an existing bucket.
+- Only a missing bucket is created; an existing bucket is used as-is and never modified, so
+  operator-managed settings are preserved. `ConfigureBucket` therefore only applies when the bucket is
+  first created.
+- Creating a bucket requires JetStream stream-management permissions.
 - Overriding `History` (away from `1`) or clearing `LimitMarkerTTL` in `ConfigureBucket` disables
   reliable per-key TTL.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A .NET 8+ library (tested on .NET 8 and .NET 10) for using NATS with `HybridCach
 ## Requirements
 
 - NATS 2.11 or later
-- A NATS KV bucket with `LimitMarkerTTL` set for per-key TTL support. Example:
+- A NATS KV bucket with `LimitMarkerTTL` set for per-key TTL support. Either enable
+  [automatic bucket creation](#automatic-bucket-creation) (`options.CreateBucketIfNotExists = true`), or
+  pre-create the bucket yourself:
     ```csharp
     // assuming an INatsConnection natsConnection
     var kvContext = natsConnection.CreateKeyValueStoreContext();
@@ -37,8 +39,6 @@ dotnet add package NATS.Extensions.Microsoft.DependencyInjection
 using CodeCargo.Nats.HybridCacheExtensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
 using NATS.Net;
 
@@ -56,18 +56,14 @@ builder.ConfigureServices(services =>
     services.AddNatsHybridCache(options =>
     {
         options.BucketName = "cache";
+
+        // Create the KV bucket on first use if it doesn't already exist.
+        // Omit this if you pre-create the bucket yourself (see Requirements).
+        options.CreateBucketIfNotExists = true;
     });
 });
 
 var host = builder.Build();
-
-// Ensure that the KV Store is created
-var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-var kvContext = natsConnection.CreateKeyValueStoreContext();
-await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache")
-{
-    LimitMarkerTTL = TimeSpan.FromSeconds(1)
-});
 
 // Start the host
 await host.RunAsync();
@@ -88,8 +84,6 @@ dotnet add package NATS.Extensions.Microsoft.DependencyInjection
 using CodeCargo.Nats.DistributedCache;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
 using NATS.Net;
 
@@ -107,19 +101,58 @@ builder.ConfigureServices(services =>
     services.AddNatsDistributedCache(options =>
     {
         options.BucketName = "cache";
+
+        // Create the KV bucket on first use if it doesn't already exist.
+        // Omit this if you pre-create the bucket yourself (see Requirements).
+        options.CreateBucketIfNotExists = true;
     });
 });
 
 var host = builder.Build();
 
-// Ensure that the KV Store is created
-var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-var kvContext = natsConnection.CreateKeyValueStoreContext();
-await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1) });
-
 // Start the host
 await host.RunAsync();
 ```
+
+## Automatic bucket creation
+
+By default the KV bucket must already exist. Set `CreateBucketIfNotExists = true` to have the cache
+create it (via `CreateOrUpdateStoreAsync`) on first use, with the settings per-key TTL requires —
+`History = 1` and a non-zero `LimitMarkerTTL`:
+
+```csharp
+services.AddNatsDistributedCache(options =>
+{
+    options.BucketName = "cache";
+    options.CreateBucketIfNotExists = true;
+});
+```
+
+To customize storage, replication, or size limits, use `ConfigureBucket`. `NatsKVConfig` is an
+immutable record, so return a modified copy with a `with` expression:
+
+```csharp
+using NATS.Client.KeyValueStore;
+
+services.AddNatsDistributedCache(options =>
+{
+    options.BucketName = "cache";
+    options.CreateBucketIfNotExists = true;
+    options.ConfigureBucket = config => config with
+    {
+        Storage = NatsKVStorageType.File,
+        NumberOfReplicas = 3,
+    };
+});
+```
+
+Notes:
+
+- Creating or updating a bucket requires JetStream stream-management permissions.
+- Because `CreateOrUpdateStoreAsync` is used, an existing bucket is also updated to match the resolved
+  config; immutable properties (for example `Storage`) can't be changed on an existing bucket.
+- Overriding `History` (away from `1`) or clearing `LimitMarkerTTL` in `ConfigureBucket` disables
+  reliable per-key TTL.
 
 ## Controlling Expiration Timing
 

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -274,7 +274,9 @@ public partial class NatsCache : IBufferDistributedCache
 
         if (_configureBucket != null)
         {
-            config = _configureBucket(config);
+            config = _configureBucket(config)
+                     ?? throw new InvalidOperationException(
+                         $"{nameof(NatsCacheOptions)}.{nameof(NatsCacheOptions.ConfigureBucket)} must not return null.");
             if (config.Bucket != _bucketName)
             {
                 config = config with { Bucket = _bucketName };
@@ -296,6 +298,24 @@ public partial class NatsCache : IBufferDistributedCache
             ? _keyEncoder.Encode(key)
             : _keyEncoder.Encode($"{_keyPrefix}.{key}");
 
+    // Returns the KV store for the configured bucket, creating it first only if it does not already exist.
+    // An existing (operator-managed) bucket is used as-is and never modified — matching the
+    // CreateBucketIfNotExists contract — so CreateStoreAsync is used rather than CreateOrUpdateStoreAsync.
+    // A create that loses a race with a concurrent creator surfaces as a failure and is retried via the
+    // reset-on-failure path in CreateLazyKvStore.
+    private async Task<INatsKVStore> GetOrCreateStoreAsync(INatsKVContext kv)
+    {
+        await foreach (var bucket in kv.GetBucketNamesAsync().ConfigureAwait(false))
+        {
+            if (bucket == _bucketName)
+            {
+                return await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
+            }
+        }
+
+        return await kv.CreateStoreAsync(BuildBucketConfig()).ConfigureAwait(false);
+    }
+
     private Lazy<Task<INatsKVStore>> CreateLazyKvStore() =>
         new(async () =>
         {
@@ -303,7 +323,7 @@ public partial class NatsCache : IBufferDistributedCache
             {
                 var kv = _natsConnection.CreateKeyValueStoreContext();
                 var store = _createBucketIfNotExists
-                    ? await kv.CreateOrUpdateStoreAsync(BuildBucketConfig()).ConfigureAwait(false)
+                    ? await GetOrCreateStoreAsync(kv).ConfigureAwait(false)
                     : await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
                 LogConnected(_bucketName);
                 return store;

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -29,7 +29,12 @@ public partial class NatsCache : IBufferDistributedCache
     // Compact binary serializer for the CacheEntry envelope (replaces the previous JSON+base64 format).
     private static readonly CacheEntryBinarySerializer CacheEntrySerializer = CacheEntryBinarySerializer.Default;
 
+    // Non-zero LimitMarkerTTL enables per-key TTL (NATS 2.11+); the actual per-key expiry is set per Put.
+    private static readonly TimeSpan DefaultLimitMarkerTtl = TimeSpan.FromSeconds(1);
+
     private readonly string _bucketName;
+    private readonly bool _createBucketIfNotExists;
+    private readonly Func<NatsKVConfig, NatsKVConfig>? _configureBucket;
     private readonly INatsCacheKeyEncoder _keyEncoder;
     private readonly string _keyPrefix;
     private readonly ILogger _logger;
@@ -49,6 +54,8 @@ public partial class NatsCache : IBufferDistributedCache
         _keyPrefix = string.IsNullOrEmpty(options.CacheKeyPrefix)
             ? string.Empty
             : options.CacheKeyPrefix.TrimEnd('.');
+        _createBucketIfNotExists = options.CreateBucketIfNotExists;
+        _configureBucket = options.ConfigureBucket;
         _lazyKvStore = CreateLazyKvStore();
         _natsConnection = natsConnection;
         _logger = logger ?? NullLogger<NatsCache>.Instance;
@@ -252,6 +259,31 @@ public partial class NatsCache : IBufferDistributedCache
     internal bool IsAbsolutelyExpired(CacheEntry entry) =>
         entry.AbsoluteExpiration.HasValue && TimeProvider.GetUtcNow() >= entry.AbsoluteExpiration.Value;
 
+    // Builds the NatsKVConfig used when CreateBucketIfNotExists is enabled. Pure and synchronous (does not
+    // touch the NATS connection), so it is unit-testable without a server. Cache-appropriate defaults are
+    // applied first, then the user hook (a record `with` transform) may override them. The bucket name is
+    // re-asserted afterward so the hook cannot retarget creation to a bucket other than the one GetKvStore
+    // reads from.
+    internal NatsKVConfig BuildBucketConfig()
+    {
+        var config = new NatsKVConfig(_bucketName)
+        {
+            History = 1, // required for well-defined per-key TTL behavior
+            LimitMarkerTTL = DefaultLimitMarkerTtl, // non-zero => enables per-key TTL (NATS 2.11+)
+        };
+
+        if (_configureBucket != null)
+        {
+            config = _configureBucket(config);
+            if (config.Bucket != _bucketName)
+            {
+                config = config with { Bucket = _bucketName };
+            }
+        }
+
+        return config;
+    }
+
     // Resolves the effective absolute expiration instant: a relative expiration (offset from the
     // current clock) takes precedence over an explicit absolute expiration when both are set.
     private DateTimeOffset? ResolveAbsoluteExpiration(DistributedCacheEntryOptions options) =>
@@ -270,7 +302,9 @@ public partial class NatsCache : IBufferDistributedCache
             try
             {
                 var kv = _natsConnection.CreateKeyValueStoreContext();
-                var store = await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
+                var store = _createBucketIfNotExists
+                    ? await kv.CreateOrUpdateStoreAsync(BuildBucketConfig()).ConfigureAwait(false)
+                    : await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
                 LogConnected(_bucketName);
                 return store;
             }

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NATS.Client.Core;
+using NATS.Client.JetStream;
 using NATS.Client.KeyValueStore;
 using NATS.Net;
 
@@ -26,6 +27,10 @@ public class CacheEntry
 /// </summary>
 public partial class NatsCache : IBufferDistributedCache
 {
+    // JetStream "stream not found" error code (JSStreamNotFoundErr), returned by GetStoreAsync when the
+    // KV bucket does not exist.
+    private const int StreamNotFoundErrCode = 10059;
+
     // Compact binary serializer for the CacheEntry envelope (replaces the previous JSON+base64 format).
     private static readonly CacheEntryBinarySerializer CacheEntrySerializer = CacheEntryBinarySerializer.Default;
 
@@ -298,22 +303,23 @@ public partial class NatsCache : IBufferDistributedCache
             ? _keyEncoder.Encode(key)
             : _keyEncoder.Encode($"{_keyPrefix}.{key}");
 
-    // Returns the KV store for the configured bucket, creating it first only if it does not already exist.
-    // An existing (operator-managed) bucket is used as-is and never modified — matching the
+    // Returns the KV store for the configured bucket, creating it only if it does not already exist. An
+    // existing (operator-managed) bucket is used as-is and never modified — matching the
     // CreateBucketIfNotExists contract — so CreateStoreAsync is used rather than CreateOrUpdateStoreAsync.
-    // A create that loses a race with a concurrent creator surfaces as a failure and is retried via the
-    // reset-on-failure path in CreateLazyKvStore.
+    // GetStoreAsync is attempted first (rather than listing every bucket) so this stays O(1) and needs no
+    // stream-list permission; only a genuine "stream not found" triggers creation, and any other error
+    // (connectivity, auth) propagates unchanged. A create that loses a race with a concurrent creator
+    // surfaces as a failure and is retried via the reset-on-failure path in CreateLazyKvStore.
     private async Task<INatsKVStore> GetOrCreateStoreAsync(INatsKVContext kv)
     {
-        await foreach (var bucket in kv.GetBucketNamesAsync().ConfigureAwait(false))
+        try
         {
-            if (bucket == _bucketName)
-            {
-                return await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
-            }
+            return await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
         }
-
-        return await kv.CreateStoreAsync(BuildBucketConfig()).ConfigureAwait(false);
+        catch (NatsJSApiException ex) when (ex.Error.ErrCode == StreamNotFoundErrCode)
+        {
+            return await kv.CreateStoreAsync(BuildBucketConfig()).ConfigureAwait(false);
+        }
     }
 
     private Lazy<Task<INatsKVStore>> CreateLazyKvStore() =>

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -316,8 +316,9 @@ public partial class NatsCache : IBufferDistributedCache
         {
             return await kv.GetStoreAsync(_bucketName).ConfigureAwait(false);
         }
-        catch (NatsJSApiException ex) when (ex.Error.ErrCode == StreamNotFoundErrCode)
+        catch (NatsJSApiException ex) when (ex.Error is { ErrCode: StreamNotFoundErrCode })
         {
+            // Null-safe pattern: a null Error simply doesn't match, so the filter is false rather than throwing.
             return await kv.CreateStoreAsync(BuildBucketConfig()).ConfigureAwait(false);
         }
     }

--- a/src/NatsDistributedCache/NatsCache.cs
+++ b/src/NatsDistributedCache/NatsCache.cs
@@ -39,7 +39,7 @@ public partial class NatsCache : IBufferDistributedCache
 
     private readonly string _bucketName;
     private readonly bool _createBucketIfNotExists;
-    private readonly Func<NatsKVConfig, NatsKVConfig>? _configureBucket;
+    private readonly Func<NatsKVConfig, NatsKVConfig>? _configureBucketOnCreate;
     private readonly INatsCacheKeyEncoder _keyEncoder;
     private readonly string _keyPrefix;
     private readonly ILogger _logger;
@@ -60,7 +60,7 @@ public partial class NatsCache : IBufferDistributedCache
             ? string.Empty
             : options.CacheKeyPrefix.TrimEnd('.');
         _createBucketIfNotExists = options.CreateBucketIfNotExists;
-        _configureBucket = options.ConfigureBucket;
+        _configureBucketOnCreate = options.ConfigureBucketOnCreate;
         _lazyKvStore = CreateLazyKvStore();
         _natsConnection = natsConnection;
         _logger = logger ?? NullLogger<NatsCache>.Instance;
@@ -277,11 +277,11 @@ public partial class NatsCache : IBufferDistributedCache
             LimitMarkerTTL = DefaultLimitMarkerTtl, // non-zero => enables per-key TTL (NATS 2.11+)
         };
 
-        if (_configureBucket != null)
+        if (_configureBucketOnCreate != null)
         {
-            config = _configureBucket(config)
+            config = _configureBucketOnCreate(config)
                      ?? throw new InvalidOperationException(
-                         $"{nameof(NatsCacheOptions)}.{nameof(NatsCacheOptions.ConfigureBucket)} must not return null.");
+                         $"{nameof(NatsCacheOptions)}.{nameof(NatsCacheOptions.ConfigureBucketOnCreate)} must not return null.");
             if (config.Bucket != _bucketName)
             {
                 config = config with { Bucket = _bucketName };

--- a/src/NatsDistributedCache/NatsCacheOptions.cs
+++ b/src/NatsDistributedCache/NatsCacheOptions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using NATS.Client.KeyValueStore;
 
 namespace CodeCargo.Nats.DistributedCache
 {
@@ -21,6 +22,41 @@ namespace CodeCargo.Nats.DistributedCache
         /// Allows partitioning a single backend cache for use with multiple apps/services.
         /// </summary>
         public string? CacheKeyPrefix { get; set; }
+
+        /// <summary>
+        /// When <see langword="true"/>, the <see cref="BucketName"/> KV bucket is created (via
+        /// <c>CreateOrUpdateStoreAsync</c>) the first time the cache is used, if it does not already exist.
+        /// Defaults to <see langword="false"/>, in which case the bucket must be pre-created by the operator.
+        /// </summary>
+        /// <remarks>
+        /// Because <c>CreateOrUpdateStoreAsync</c> is used, an existing bucket is also updated to match the
+        /// resolved <see cref="NatsKVConfig"/>; immutable properties (for example <c>Storage</c>) cannot be
+        /// changed on an existing bucket and will surface an error on first use. Creating or updating a bucket
+        /// requires JetStream stream-management permissions.
+        /// </remarks>
+        public bool CreateBucketIfNotExists { get; set; }
+
+        /// <summary>
+        /// Optional hook to customize the <see cref="NatsKVConfig"/> used when
+        /// <see cref="CreateBucketIfNotExists"/> is enabled (for example <c>Storage</c>,
+        /// <c>NumberOfReplicas</c>, <c>MaxBytes</c>, or <c>MaxAge</c>). Ignored when
+        /// <see cref="CreateBucketIfNotExists"/> is <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="NatsKVConfig"/> is an immutable record, so the hook receives the pre-populated config
+        /// and returns a modified copy using a <c>with</c> expression, for example
+        /// <c>options.ConfigureBucket = cfg =&gt; cfg with { Storage = NatsKVStorageType.Memory };</c>.
+        /// </para>
+        /// <para>
+        /// The library pre-populates the config with cache-appropriate defaults — <c>History = 1</c> and a
+        /// non-zero <c>LimitMarkerTTL</c>, both required for per-key TTL on NATS 2.11+ — before this hook runs,
+        /// so the hook can override any property. The <c>Bucket</c> name is always forced back to
+        /// <see cref="BucketName"/> afterward. Overriding <c>History</c> to a value other than 1, or clearing
+        /// <c>LimitMarkerTTL</c>, disables reliable per-key TTL.
+        /// </para>
+        /// </remarks>
+        public Func<NatsKVConfig, NatsKVConfig>? ConfigureBucket { get; set; }
 
         NatsCacheOptions IOptions<NatsCacheOptions>.Value => this;
     }

--- a/src/NatsDistributedCache/NatsCacheOptions.cs
+++ b/src/NatsDistributedCache/NatsCacheOptions.cs
@@ -45,7 +45,7 @@ namespace CodeCargo.Nats.DistributedCache
         /// <para>
         /// <see cref="NatsKVConfig"/> is an immutable record, so the hook receives the pre-populated config
         /// and returns a modified copy using a <c>with</c> expression, for example
-        /// <c>options.ConfigureBucket = cfg =&gt; cfg with { Storage = NatsKVStorageType.Memory };</c>.
+        /// <c>options.ConfigureBucketOnCreate = cfg =&gt; cfg with { Storage = NatsKVStorageType.Memory };</c>.
         /// </para>
         /// <para>
         /// The library pre-populates the config with cache-appropriate defaults — <c>History = 1</c> and a
@@ -55,7 +55,7 @@ namespace CodeCargo.Nats.DistributedCache
         /// <c>LimitMarkerTTL</c>, disables reliable per-key TTL.
         /// </para>
         /// </remarks>
-        public Func<NatsKVConfig, NatsKVConfig>? ConfigureBucket { get; set; }
+        public Func<NatsKVConfig, NatsKVConfig>? ConfigureBucketOnCreate { get; set; }
 
         NatsCacheOptions IOptions<NatsCacheOptions>.Value => this;
     }

--- a/src/NatsDistributedCache/NatsCacheOptions.cs
+++ b/src/NatsDistributedCache/NatsCacheOptions.cs
@@ -24,23 +24,22 @@ namespace CodeCargo.Nats.DistributedCache
         public string? CacheKeyPrefix { get; set; }
 
         /// <summary>
-        /// When <see langword="true"/>, the <see cref="BucketName"/> KV bucket is created (via
-        /// <c>CreateOrUpdateStoreAsync</c>) the first time the cache is used, if it does not already exist.
-        /// Defaults to <see langword="false"/>, in which case the bucket must be pre-created by the operator.
+        /// When <see langword="true"/>, the <see cref="BucketName"/> KV bucket is created the first time the
+        /// cache is used, if it does not already exist. Defaults to <see langword="false"/>, in which case the
+        /// bucket must be pre-created by the operator.
         /// </summary>
         /// <remarks>
-        /// Because <c>CreateOrUpdateStoreAsync</c> is used, an existing bucket is also updated to match the
-        /// resolved <see cref="NatsKVConfig"/>; immutable properties (for example <c>Storage</c>) cannot be
-        /// changed on an existing bucket and will surface an error on first use. Creating or updating a bucket
-        /// requires JetStream stream-management permissions.
+        /// Only a missing bucket is created; an existing bucket is used as-is and never modified, so
+        /// operator-managed settings are preserved. Creating a bucket requires JetStream stream-management
+        /// permissions.
         /// </remarks>
         public bool CreateBucketIfNotExists { get; set; }
 
         /// <summary>
         /// Optional hook to customize the <see cref="NatsKVConfig"/> used when
-        /// <see cref="CreateBucketIfNotExists"/> is enabled (for example <c>Storage</c>,
-        /// <c>NumberOfReplicas</c>, <c>MaxBytes</c>, or <c>MaxAge</c>). Ignored when
-        /// <see cref="CreateBucketIfNotExists"/> is <see langword="false"/>.
+        /// <see cref="CreateBucketIfNotExists"/> is enabled and a missing bucket is created (for example
+        /// <c>Storage</c>, <c>NumberOfReplicas</c>, <c>MaxBytes</c>, or <c>MaxAge</c>). Ignored when
+        /// <see cref="CreateBucketIfNotExists"/> is <see langword="false"/> or the bucket already exists.
         /// </summary>
         /// <remarks>
         /// <para>

--- a/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
+++ b/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
@@ -7,45 +7,29 @@ using NATS.Net;
 namespace CodeCargo.Nats.DistributedCache.IntegrationTests.Cache;
 
 /// <summary>
-/// Verifies opt-in bucket auto-creation (issue #38). Uses a bucket distinct from the shared "cache"
-/// bucket so it never collides with <see cref="TestBase"/>'s KV_cache purge, and deletes the
-/// auto-created bucket on teardown so nothing leaks across the collection lifetime.
+/// Verifies opt-in bucket auto-creation (issue #38). Uses buckets distinct from the shared "cache"
+/// bucket so they never collide with <see cref="TestBase"/>'s KV_cache purge, and deletes any
+/// bucket it touches on teardown so nothing leaks across the collection lifetime.
 /// </summary>
 [Collection(NatsCollection.Name)]
-public class BucketAutoCreationTests : IAsyncLifetime
+public class BucketAutoCreationTests(NatsIntegrationFixture fixture) : IAsyncLifetime
 {
-    private const string BucketName = "auto-created-cache";
     private const string Key = "auto-create-key";
 
-    private readonly NatsIntegrationFixture _fixture;
-    private readonly ServiceProvider _serviceProvider;
-
-    public BucketAutoCreationTests(NatsIntegrationFixture fixture)
-    {
-        _fixture = fixture;
-
-        var services = new ServiceCollection();
-        services.AddLogging();
-        fixture.ConfigureServices(services);
-        services.AddNatsDistributedCache(options =>
-        {
-            options.BucketName = BucketName;
-            options.CreateBucketIfNotExists = true;
-
-            // Memory storage keeps the test light and exercises the ConfigureBucket hook end-to-end.
-            options.ConfigureBucket = cfg => cfg with { Storage = NatsKVStorageType.Memory };
-        });
-        _serviceProvider = services.BuildServiceProvider();
-    }
+    private readonly List<ServiceProvider> _serviceProviders = new();
+    private readonly List<string> _bucketsToDelete = new();
 
     [Fact]
-    public async Task FirstOperation_AutoCreatesBucket_WithHistoryOneAndLimitMarkerTtl()
+    public async Task FirstOperation_CreatesMissingBucket_WithHistoryOneAndLimitMarkerTtl()
     {
+        const string bucketName = "auto-created-cache";
         var ct = TestContext.Current.CancellationToken;
-        var cache = _serviceProvider.GetRequiredService<IDistributedCache>();
+
+        // Memory storage keeps the test light and exercises the ConfigureBucket hook end-to-end.
+        var cache = BuildCache(bucketName, cfg => cfg with { Storage = NatsKVStorageType.Memory });
         var value = new byte[] { 1, 2, 3 };
 
-        // The first cache operation triggers the lazy CreateOrUpdateStoreAsync against a missing bucket.
+        // The first cache operation triggers creation of the missing bucket.
         await cache.SetAsync(
             Key,
             value,
@@ -55,28 +39,100 @@ public class BucketAutoCreationTests : IAsyncLifetime
         Assert.Equal(value, await cache.GetAsync(Key, ct));
 
         // The bucket now exists with the cache-required config: History = 1 and a non-zero LimitMarkerTTL.
-        var kv = _fixture.NatsConnection.CreateKeyValueStoreContext();
-        var status = await (await kv.GetStoreAsync(BucketName, ct)).GetStatusAsync(ct);
-        Assert.Equal(BucketName, status.Bucket);
+        var status = await GetStatusAsync(bucketName, ct);
+        Assert.Equal(bucketName, status.Bucket);
         Assert.NotEqual(TimeSpan.Zero, status.LimitMarkerTTL);
         Assert.Equal(1, status.Info.Config.MaxMsgsPerSubject); // KV History maps to MaxMsgsPerSubject
+    }
+
+    [Fact]
+    public async Task ExistingBucket_IsUsedAsIs_AndNeverModified()
+    {
+        const string bucketName = "operator-managed-cache";
+        var ct = TestContext.Current.CancellationToken;
+
+        // Operator pre-creates the bucket with a distinctive LimitMarkerTTL (5s).
+        var kv = fixture.NatsConnection.CreateKeyValueStoreContext();
+        _bucketsToDelete.Add(bucketName);
+        await kv.CreateStoreAsync(
+            new NatsKVConfig(bucketName)
+            {
+                History = 1,
+                LimitMarkerTTL = TimeSpan.FromSeconds(5),
+                Storage = NatsKVStorageType.Memory,
+            },
+            ct);
+
+        // Enable auto-create with a hook that WOULD set a different LimitMarkerTTL (1s) if it created the bucket.
+        var cache = BuildCache(
+            bucketName,
+            cfg => cfg with { LimitMarkerTTL = TimeSpan.FromSeconds(1), Storage = NatsKVStorageType.Memory },
+            trackForDeletion: false);
+
+        await cache.SetAsync(
+            Key,
+            new byte[] { 9 },
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1) },
+            ct);
+
+        // The pre-existing bucket must be left untouched: LimitMarkerTTL is still the operator's 5s, not 1s.
+        var status = await GetStatusAsync(bucketName, ct);
+        Assert.Equal(TimeSpan.FromSeconds(5), status.LimitMarkerTTL);
     }
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
     public async ValueTask DisposeAsync()
     {
-        try
+        var kv = fixture.NatsConnection.CreateKeyValueStoreContext();
+        foreach (var bucket in _bucketsToDelete)
         {
-            var kv = _fixture.NatsConnection.CreateKeyValueStoreContext();
-            await kv.DeleteStoreAsync(BucketName, TestContext.Current.CancellationToken);
-        }
-        catch
-        {
-            // Best-effort cleanup; the memory-backed bucket is discarded when the server stops regardless.
+            try
+            {
+                await kv.DeleteStoreAsync(bucket, TestContext.Current.CancellationToken);
+            }
+            catch
+            {
+                // Best-effort cleanup; memory-backed buckets are discarded when the server stops regardless.
+            }
         }
 
-        await _serviceProvider.DisposeAsync();
+        foreach (var sp in _serviceProviders)
+        {
+            await sp.DisposeAsync();
+        }
+
         GC.SuppressFinalize(this);
+    }
+
+    private IDistributedCache BuildCache(
+        string bucketName,
+        Func<NatsKVConfig, NatsKVConfig> configureBucket,
+        bool trackForDeletion = true)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        fixture.ConfigureServices(services);
+        services.AddNatsDistributedCache(options =>
+        {
+            options.BucketName = bucketName;
+            options.CreateBucketIfNotExists = true;
+            options.ConfigureBucket = configureBucket;
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        _serviceProviders.Add(serviceProvider);
+        if (trackForDeletion)
+        {
+            _bucketsToDelete.Add(bucketName);
+        }
+
+        return serviceProvider.GetRequiredService<IDistributedCache>();
+    }
+
+    private async Task<NatsKVStatus> GetStatusAsync(string bucketName, CancellationToken ct)
+    {
+        var kv = fixture.NatsConnection.CreateKeyValueStoreContext();
+        return await (await kv.GetStoreAsync(bucketName, ct)).GetStatusAsync(ct);
     }
 }

--- a/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
+++ b/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
@@ -25,7 +25,7 @@ public class BucketAutoCreationTests(NatsIntegrationFixture fixture) : IAsyncLif
         const string bucketName = "auto-created-cache";
         var ct = TestContext.Current.CancellationToken;
 
-        // Memory storage keeps the test light and exercises the ConfigureBucket hook end-to-end.
+        // Memory storage keeps the test light and exercises the ConfigureBucketOnCreate hook end-to-end.
         var cache = BuildCache(bucketName, cfg => cfg with { Storage = NatsKVStorageType.Memory });
         var value = new byte[] { 1, 2, 3 };
 
@@ -117,7 +117,7 @@ public class BucketAutoCreationTests(NatsIntegrationFixture fixture) : IAsyncLif
         {
             options.BucketName = bucketName;
             options.CreateBucketIfNotExists = true;
-            options.ConfigureBucket = configureBucket;
+            options.ConfigureBucketOnCreate = configureBucket;
         });
 
         var serviceProvider = services.BuildServiceProvider();

--- a/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
+++ b/test/IntegrationTests/Cache/BucketAutoCreationTests.cs
@@ -1,0 +1,82 @@
+using CodeCargo.Nats.DistributedCache.TestUtils;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using NATS.Client.KeyValueStore;
+using NATS.Net;
+
+namespace CodeCargo.Nats.DistributedCache.IntegrationTests.Cache;
+
+/// <summary>
+/// Verifies opt-in bucket auto-creation (issue #38). Uses a bucket distinct from the shared "cache"
+/// bucket so it never collides with <see cref="TestBase"/>'s KV_cache purge, and deletes the
+/// auto-created bucket on teardown so nothing leaks across the collection lifetime.
+/// </summary>
+[Collection(NatsCollection.Name)]
+public class BucketAutoCreationTests : IAsyncLifetime
+{
+    private const string BucketName = "auto-created-cache";
+    private const string Key = "auto-create-key";
+
+    private readonly NatsIntegrationFixture _fixture;
+    private readonly ServiceProvider _serviceProvider;
+
+    public BucketAutoCreationTests(NatsIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        fixture.ConfigureServices(services);
+        services.AddNatsDistributedCache(options =>
+        {
+            options.BucketName = BucketName;
+            options.CreateBucketIfNotExists = true;
+
+            // Memory storage keeps the test light and exercises the ConfigureBucket hook end-to-end.
+            options.ConfigureBucket = cfg => cfg with { Storage = NatsKVStorageType.Memory };
+        });
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task FirstOperation_AutoCreatesBucket_WithHistoryOneAndLimitMarkerTtl()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var cache = _serviceProvider.GetRequiredService<IDistributedCache>();
+        var value = new byte[] { 1, 2, 3 };
+
+        // The first cache operation triggers the lazy CreateOrUpdateStoreAsync against a missing bucket.
+        await cache.SetAsync(
+            Key,
+            value,
+            new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1) },
+            ct);
+
+        Assert.Equal(value, await cache.GetAsync(Key, ct));
+
+        // The bucket now exists with the cache-required config: History = 1 and a non-zero LimitMarkerTTL.
+        var kv = _fixture.NatsConnection.CreateKeyValueStoreContext();
+        var status = await (await kv.GetStoreAsync(BucketName, ct)).GetStatusAsync(ct);
+        Assert.Equal(BucketName, status.Bucket);
+        Assert.NotEqual(TimeSpan.Zero, status.LimitMarkerTTL);
+        Assert.Equal(1, status.Info.Config.MaxMsgsPerSubject); // KV History maps to MaxMsgsPerSubject
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            var kv = _fixture.NatsConnection.CreateKeyValueStoreContext();
+            await kv.DeleteStoreAsync(BucketName, TestContext.Current.CancellationToken);
+        }
+        catch
+        {
+            // Best-effort cleanup; the memory-backed bucket is discarded when the server stops regardless.
+        }
+
+        await _serviceProvider.DisposeAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/test/UnitTests/Cache/BucketConfigUnitTests.cs
+++ b/test/UnitTests/Cache/BucketConfigUnitTests.cs
@@ -71,6 +71,15 @@ public class BucketConfigUnitTests
         Assert.Equal(BucketName, config.Bucket);
     }
 
+    [Fact]
+    public void BuildBucketConfig_ThrowsClearException_WhenHookReturnsNull()
+    {
+        var cache = CreateCache(o => o.ConfigureBucket = _ => null!);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => cache.BuildBucketConfig());
+        Assert.Contains(nameof(NatsCacheOptions.ConfigureBucket), ex.Message);
+    }
+
     // BuildBucketConfig never touches the connection, so a bare mock is sufficient and no server is needed.
     private static NatsCache CreateCache(Action<NatsCacheOptions>? configure = null)
     {

--- a/test/UnitTests/Cache/BucketConfigUnitTests.cs
+++ b/test/UnitTests/Cache/BucketConfigUnitTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using NATS.Client.Core;
+using NATS.Client.KeyValueStore;
+
+namespace CodeCargo.Nats.DistributedCache.UnitTests.Cache;
+
+public class BucketConfigUnitTests
+{
+    private const string BucketName = "cache";
+
+    [Fact]
+    public void BuildBucketConfig_SetsBucketName()
+    {
+        var config = CreateCache().BuildBucketConfig();
+
+        Assert.Equal(BucketName, config.Bucket);
+    }
+
+    [Fact]
+    public void BuildBucketConfig_DefaultsHistoryToOne()
+    {
+        var config = CreateCache().BuildBucketConfig();
+
+        Assert.Equal(1, config.History);
+    }
+
+    [Fact]
+    public void BuildBucketConfig_SetsNonZeroLimitMarkerTtl()
+    {
+        var config = CreateCache().BuildBucketConfig();
+
+        Assert.NotEqual(TimeSpan.Zero, config.LimitMarkerTTL);
+        Assert.Equal(TimeSpan.FromSeconds(1), config.LimitMarkerTTL);
+    }
+
+    [Fact]
+    public void BuildBucketConfig_InvokesConfigureBucketHook()
+    {
+        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with
+        {
+            Storage = NatsKVStorageType.Memory,
+            NumberOfReplicas = 3,
+        }).BuildBucketConfig();
+
+        Assert.Equal(NatsKVStorageType.Memory, config.Storage);
+        Assert.Equal(3, config.NumberOfReplicas);
+    }
+
+    [Fact]
+    public void BuildBucketConfig_HookCanOverrideDefaults()
+    {
+        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with
+        {
+            History = 5,
+            LimitMarkerTTL = TimeSpan.FromSeconds(30),
+        }).BuildBucketConfig();
+
+        // The hook runs after the defaults, so it wins (documented as caller responsibility for TTL correctness).
+        Assert.Equal(5, config.History);
+        Assert.Equal(TimeSpan.FromSeconds(30), config.LimitMarkerTTL);
+    }
+
+    [Fact]
+    public void BuildBucketConfig_ReassertsBucketName_WhenHookChangesIt()
+    {
+        // The hook must not be able to retarget creation to a different bucket than the cache reads from.
+        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with { Bucket = "some-other-bucket" })
+            .BuildBucketConfig();
+
+        Assert.Equal(BucketName, config.Bucket);
+    }
+
+    // BuildBucketConfig never touches the connection, so a bare mock is sufficient and no server is needed.
+    private static NatsCache CreateCache(Action<NatsCacheOptions>? configure = null)
+    {
+        var options = new NatsCacheOptions { BucketName = BucketName, CreateBucketIfNotExists = true };
+        configure?.Invoke(options);
+        return new NatsCache(Options.Create(options), new Mock<INatsConnection>().Object);
+    }
+}

--- a/test/UnitTests/Cache/BucketConfigUnitTests.cs
+++ b/test/UnitTests/Cache/BucketConfigUnitTests.cs
@@ -35,9 +35,9 @@ public class BucketConfigUnitTests
     }
 
     [Fact]
-    public void BuildBucketConfig_InvokesConfigureBucketHook()
+    public void BuildBucketConfig_InvokesConfigureBucketOnCreateHook()
     {
-        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with
+        var config = CreateCache(o => o.ConfigureBucketOnCreate = cfg => cfg with
         {
             Storage = NatsKVStorageType.Memory,
             NumberOfReplicas = 3,
@@ -50,7 +50,7 @@ public class BucketConfigUnitTests
     [Fact]
     public void BuildBucketConfig_HookCanOverrideDefaults()
     {
-        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with
+        var config = CreateCache(o => o.ConfigureBucketOnCreate = cfg => cfg with
         {
             History = 5,
             LimitMarkerTTL = TimeSpan.FromSeconds(30),
@@ -65,7 +65,7 @@ public class BucketConfigUnitTests
     public void BuildBucketConfig_ReassertsBucketName_WhenHookChangesIt()
     {
         // The hook must not be able to retarget creation to a different bucket than the cache reads from.
-        var config = CreateCache(o => o.ConfigureBucket = cfg => cfg with { Bucket = "some-other-bucket" })
+        var config = CreateCache(o => o.ConfigureBucketOnCreate = cfg => cfg with { Bucket = "some-other-bucket" })
             .BuildBucketConfig();
 
         Assert.Equal(BucketName, config.Bucket);
@@ -74,10 +74,10 @@ public class BucketConfigUnitTests
     [Fact]
     public void BuildBucketConfig_ThrowsClearException_WhenHookReturnsNull()
     {
-        var cache = CreateCache(o => o.ConfigureBucket = _ => null!);
+        var cache = CreateCache(o => o.ConfigureBucketOnCreate = _ => null!);
 
         var ex = Assert.Throws<InvalidOperationException>(() => cache.BuildBucketConfig());
-        Assert.Contains(nameof(NatsCacheOptions.ConfigureBucket), ex.Message);
+        Assert.Contains(nameof(NatsCacheOptions.ConfigureBucketOnCreate), ex.Message);
     }
 
     // BuildBucketConfig never touches the connection, so a bare mock is sufficient and no server is needed.

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using NATS.Client.Core;
+using NATS.Client.KeyValueStore;
 
 namespace CodeCargo.Nats.DistributedCache.UnitTests.Extensions;
 
@@ -77,6 +78,41 @@ public class CacheServiceExtensionsUnitTests
         // Assert
         Assert.Equal(expectedNamespace, options.CacheKeyPrefix);
         Assert.Equal("cache", options.BucketName);
+    }
+
+    [Fact]
+    public void AddNatsCache_SetsBucketCreationOptions()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(_mockNatsConnection.Object);
+        Func<NatsKVConfig, NatsKVConfig> configureBucket = cfg => cfg;
+
+        // Act
+        services.AddNatsDistributedCache(options =>
+        {
+            options.BucketName = "cache";
+            options.CreateBucketIfNotExists = true;
+            options.ConfigureBucket = configureBucket;
+        });
+
+        // Build the provider to verify options
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<NatsCacheOptions>>().Value;
+
+        // Assert
+        Assert.True(options.CreateBucketIfNotExists);
+        Assert.Same(configureBucket, options.ConfigureBucket);
+    }
+
+    [Fact]
+    public void NatsCacheOptions_BucketCreation_DefaultsToDisabled()
+    {
+        // Guards the "disabled by default / existing behavior unchanged" contract for issue #38.
+        var options = new NatsCacheOptions();
+
+        Assert.False(options.CreateBucketIfNotExists);
+        Assert.Null(options.ConfigureBucket);
     }
 
     [Fact]

--- a/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
+++ b/test/UnitTests/Extensions/NatsDistributedCacheExtensionsTests.cs
@@ -93,7 +93,7 @@ public class CacheServiceExtensionsUnitTests
         {
             options.BucketName = "cache";
             options.CreateBucketIfNotExists = true;
-            options.ConfigureBucket = configureBucket;
+            options.ConfigureBucketOnCreate = configureBucket;
         });
 
         // Build the provider to verify options
@@ -102,7 +102,7 @@ public class CacheServiceExtensionsUnitTests
 
         // Assert
         Assert.True(options.CreateBucketIfNotExists);
-        Assert.Same(configureBucket, options.ConfigureBucket);
+        Assert.Same(configureBucket, options.ConfigureBucketOnCreate);
     }
 
     [Fact]
@@ -112,7 +112,7 @@ public class CacheServiceExtensionsUnitTests
         var options = new NatsCacheOptions();
 
         Assert.False(options.CreateBucketIfNotExists);
-        Assert.Null(options.ConfigureBucket);
+        Assert.Null(options.ConfigureBucketOnCreate);
     }
 
     [Fact]

--- a/util/ReadmeExample/DistributedCache.Example.cs
+++ b/util/ReadmeExample/DistributedCache.Example.cs
@@ -1,8 +1,6 @@
 using CodeCargo.Nats.DistributedCache;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
 using NATS.Net;
 
@@ -25,15 +23,14 @@ public static class DistributedCacheExample
             services.AddNatsDistributedCache(options =>
             {
                 options.BucketName = "cache";
+
+                // Create the KV bucket on first use if it doesn't already exist.
+                // Omit this if you pre-create the bucket yourself (see Requirements).
+                options.CreateBucketIfNotExists = true;
             });
         });
 
         var host = builder.Build();
-
-        // Ensure that the KV Store is created
-        var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-        var kvContext = natsConnection.CreateKeyValueStoreContext();
-        await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1) });
 
         // Start the host
         await host.RunAsync();

--- a/util/ReadmeExample/DistributedCache.cs
+++ b/util/ReadmeExample/DistributedCache.cs
@@ -5,10 +5,7 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
-using NATS.Net;
 
 namespace CodeCargo.ReadmeExample;
 
@@ -47,6 +44,9 @@ public static class DistributedCacheStartup
             services.AddNatsDistributedCache(options =>
             {
                 options.BucketName = "cache";
+
+                // Create the KV bucket on first use if it doesn't already exist.
+                options.CreateBucketIfNotExists = true;
             });
 
             services.AddScoped<DistributedCacheService>();
@@ -54,14 +54,6 @@ public static class DistributedCacheStartup
 
         var host = builder.Build();
         var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-
-        // Ensure that the KV Store is created
-        Console.WriteLine("Creating KV store...");
-        var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-        var kvContext = natsConnection.CreateKeyValueStoreContext();
-        await kvContext.CreateOrUpdateStoreAsync(
-            new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1) }, startupCts.Token);
-        Console.WriteLine("KV store created");
 
         // Start the host
         Console.WriteLine("Starting app...");

--- a/util/ReadmeExample/HybridCache.Example.cs
+++ b/util/ReadmeExample/HybridCache.Example.cs
@@ -1,8 +1,6 @@
 using CodeCargo.Nats.HybridCacheExtensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
 using NATS.Net;
 
@@ -25,18 +23,14 @@ public static class HybridCacheExample
             services.AddNatsHybridCache(options =>
             {
                 options.BucketName = "cache";
+
+                // Create the KV bucket on first use if it doesn't already exist.
+                // Omit this if you pre-create the bucket yourself (see Requirements).
+                options.CreateBucketIfNotExists = true;
             });
         });
 
         var host = builder.Build();
-
-        // Ensure that the KV Store is created
-        var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-        var kvContext = natsConnection.CreateKeyValueStoreContext();
-        await kvContext.CreateOrUpdateStoreAsync(new NatsKVConfig("cache")
-        {
-            LimitMarkerTTL = TimeSpan.FromSeconds(1)
-        });
 
         // Start the host
         await host.RunAsync();

--- a/util/ReadmeExample/HybridCache.cs
+++ b/util/ReadmeExample/HybridCache.cs
@@ -5,10 +5,7 @@ using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using NATS.Client.Core;
-using NATS.Client.KeyValueStore;
 using NATS.Extensions.Microsoft.DependencyInjection;
-using NATS.Net;
 
 namespace CodeCargo.ReadmeExample;
 
@@ -48,6 +45,9 @@ public static class HybridCacheStartup
             services.AddNatsHybridCache(options =>
             {
                 options.BucketName = "cache";
+
+                // Create the KV bucket on first use if it doesn't already exist.
+                options.CreateBucketIfNotExists = true;
             });
 
             services.AddScoped<HybridCacheService>();
@@ -55,14 +55,6 @@ public static class HybridCacheStartup
 
         var host = builder.Build();
         var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-
-        // Ensure that the KV Store is created
-        Console.WriteLine("Creating KV store...");
-        var natsConnection = host.Services.GetRequiredService<INatsConnection>();
-        var kvContext = natsConnection.CreateKeyValueStoreContext();
-        await kvContext.CreateOrUpdateStoreAsync(
-            new NatsKVConfig("cache") { LimitMarkerTTL = TimeSpan.FromSeconds(1) }, startupCts.Token);
-        Console.WriteLine("KV store created");
 
         // Start the host
         Console.WriteLine("Starting app...");


### PR DESCRIPTION
## Summary

Adds opt-in automatic creation of the backing NATS KV bucket, so consumers no longer have to pre-create it before using the cache. Closes #38.

Previously `NatsCache` only called `GetStoreAsync(bucketName)`, which fails if the bucket doesn't exist — every consumer had to run a manual `CreateOrUpdateStoreAsync(...)` step (the most prominent step in the README). This makes that step optional.

## What's new

- **`NatsCacheOptions.CreateBucketIfNotExists`** (default `false`) — when enabled, the bucket is created on first cache use if it is missing, with the settings per-key TTL requires: `History = 1` and a non-zero `LimitMarkerTTL`.
- **`NatsCacheOptions.ConfigureBucket`** (`Func<NatsKVConfig, NatsKVConfig>`) — optional hook to customize storage / replication / limits. `NatsKVConfig` is an immutable record, so it's used with a `with` expression (the same idiom already used for `NatsOpts` elsewhere in this repo):
  ```csharp
  options.ConfigureBucket = cfg => cfg with { Storage = NatsKVStorageType.File, NumberOfReplicas = 3 };
  ```

## Behavior / design notes

- **Create-only, never update.** Only a missing bucket is created: `GetStoreAsync` is attempted first, and only if it reports the bucket is missing (JetStream "stream not found") does `CreateStoreAsync` create it. An existing operator-managed bucket is used as-is and never modified, so the option name matches the behavior. Probing with `GetStoreAsync` (rather than listing every bucket) keeps this O(1) and needs no stream-list permission; any other error propagates unchanged.
- **Lazy, on first use.** Creation happens on the first cache operation, reusing the existing lazy store resolution and reset-on-failure retry. No `IHostedService` / startup coupling, so a brief NATS outage at boot doesn't fail host startup.
- **Defaults + override order.** The library seeds `History = 1` and a non-zero `LimitMarkerTTL`, then applies `ConfigureBucket`; the `Bucket` name is always re-asserted afterward. A `ConfigureBucket` that returns `null` throws a clear `InvalidOperationException`.
- **Disabled by default** — existing behavior is unchanged when the flag is off.

## Docs

README requirements and both examples now show the opt-in flag, plus a new "Automatic bucket creation" section documenting `ConfigureBucket` and its caveats. The `util/ReadmeExample/*` samples were updated to match (manual pre-create step removed).

## Testing

- **Unit** (net8.0 + net10.0): `BuildBucketConfig` defaults / hook override / null guard, and options plumbing + defaults-to-disabled contract.
- **Integration** (real NATS via Aspire): auto-creates a missing bucket with `History = 1` + `LimitMarkerTTL`; and verifies an existing operator-managed bucket is left unmodified.
- Ran the `ReadmeExample` app end-to-end against a fresh NATS container — both the DistributedCache and HybridCache examples work with no manual bucket step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
