### PR TITLE
CodeCargo: update code-cargo/cargowall-action to v1.3.5

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: CargoWall
-      uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
+      uses: code-cargo/cargowall-action@78f9fbcb3561c6ad9289e5b740616216e8cbd232 # v1.3.5
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: CargoWall
-      uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
+      uses: code-cargo/cargowall-action@78f9fbcb3561c6ad9289e5b740616216e8cbd232 # v1.3.5
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
     - name: CargoWall
-      uses: code-cargo/cargowall-action@aa88f652e49b36a660add09311d077383dbc2ae7 # v1.3.3
+      uses: code-cargo/cargowall-action@78f9fbcb3561c6ad9289e5b740616216e8cbd232 # v1.3.5
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false


### PR DESCRIPTION
## Update code-cargo/cargowall-action

Updates all references to `code-cargo/cargowall-action` to version `v1.3.5`.

> SHA-pinned to `78f9fbcb3561c6ad9289e5b740616216e8cbd232` (v1.3.5)

### Modified workflows
- `.github/workflows/benchmark.yml`
- `.github/workflows/build.yml`
- `.github/workflows/publish.yml`

---
Generated by [CodeCargo](https://codecargo.com)