### PR TITLE
#45 Enable AOT/trim analyzers and source-generate key regex

### DIFF
--- a/src/NatsDistributedCache/NatsDistributedCache.csproj
+++ b/src/NatsDistributedCache/NatsDistributedCache.csproj
@@ -6,6 +6,11 @@
     <RootNamespace>CodeCargo.Nats.DistributedCache</RootNamespace>
     <Description>NATS implementation of IDistributedCache.</Description>
 
+    <!-- Turns on IsTrimmable + EnableTrimAnalyzer + EnableAotAnalyzer + EnableSingleFileAnalyzer so
+         trim/AOT (IL2xxx/IL3xxx) issues surface at build time. CI builds with
+         TreatWarningsAsErrors=true, so these become hard build failures. -->
+    <IsAotCompatible>true</IsAotCompatible>
+
     <!-- Assembly signing (only if key file exists) -->
     <SignAssembly Condition="Exists('$(MSBuildThisFileDirectory)..\..\keys\NatsDistributedCache.2025-05-12.snk')">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="Exists('$(MSBuildThisFileDirectory)..\..\keys\NatsDistributedCache.2025-05-12.snk')">$(MSBuildThisFileDirectory)..\..\keys\NatsDistributedCache.2025-05-12.snk</AssemblyOriginatorKeyFile>

--- a/src/NatsDistributedCache/NatsExtensions.cs
+++ b/src/NatsDistributedCache/NatsExtensions.cs
@@ -16,11 +16,10 @@ namespace CodeCargo.Nats.DistributedCache;
 /// nats-io/nats.net#852 was backed out. Re-check on future NATS.Net upgrades — once
 /// <c>PutAsync</c>/<c>UpdateAsync</c> gain TTL overloads, this class can be deleted in favor of them.
 /// </remarks>
-public static class NatsExtensions
+public static partial class NatsExtensions
 {
     private const string NatsExpectedLastSubjectSequence = "Nats-Expected-Last-Subject-Sequence";
     private const string NatsTtl = "Nats-TTL";
-    private static readonly Regex ValidKeyRegex = new(pattern: @"\A[-/_=\.a-zA-Z0-9]+\z", RegexOptions.Compiled);
     private static readonly NatsKVException KeyCannotBeEmptyException = new("Key cannot be empty");
 
     private static readonly NatsKVException KeyCannotStartOrEndWithPeriodException =
@@ -245,7 +244,7 @@ public static class NatsExtensions
             return KeyCannotStartOrEndWithPeriodException;
         }
 
-        if (!ValidKeyRegex.IsMatch(key))
+        if (!ValidKeyRegex().IsMatch(key))
         {
             return KeyContainsInvalidCharactersException;
         }
@@ -263,4 +262,9 @@ public static class NatsExtensions
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowException(Exception exception) => throw exception;
+
+    // Source-generated (AOT/trim-safe) replacement for a RegexOptions.Compiled Regex, which relied on
+    // reflection-emit. Pattern is unchanged: \A[-/_=\.a-zA-Z0-9]+\z (\A/\z anchors plus the / = . chars).
+    [GeneratedRegex(@"\A[-/_=\.a-zA-Z0-9]+\z", RegexOptions.Compiled)]
+    private static partial Regex ValidKeyRegex();
 }

--- a/src/NatsDistributedCache/packages.linux-arm64.lock.json
+++ b/src/NatsDistributedCache/packages.linux-arm64.lock.json
@@ -30,6 +30,12 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -160,6 +166,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.linux-arm64.lock.json
+++ b/src/NatsDistributedCache/packages.linux-arm64.lock.json
@@ -32,9 +32,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -169,9 +169,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.linux-x64.lock.json
+++ b/src/NatsDistributedCache/packages.linux-x64.lock.json
@@ -30,6 +30,12 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -160,6 +166,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.linux-x64.lock.json
+++ b/src/NatsDistributedCache/packages.linux-x64.lock.json
@@ -32,9 +32,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -169,9 +169,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.osx-arm64.lock.json
+++ b/src/NatsDistributedCache/packages.osx-arm64.lock.json
@@ -30,6 +30,12 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -160,6 +166,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.osx-arm64.lock.json
+++ b/src/NatsDistributedCache/packages.osx-arm64.lock.json
@@ -32,9 +32,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -169,9 +169,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.win-x64.lock.json
+++ b/src/NatsDistributedCache/packages.win-x64.lock.json
@@ -30,6 +30,12 @@
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -160,6 +166,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.Primitives": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsDistributedCache/packages.win-x64.lock.json
+++ b/src/NatsDistributedCache/packages.win-x64.lock.json
@@ -32,9 +32,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -169,9 +169,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/NatsHybridCacheExtensions.csproj
+++ b/src/NatsHybridCacheExtensions/NatsHybridCacheExtensions.csproj
@@ -6,6 +6,11 @@
     <RootNamespace>CodeCargo.Nats.HybridCacheExtensions</RootNamespace>
     <Description>Extensions for using HybridCache with NATS.</Description>
 
+    <!-- Turns on IsTrimmable + EnableTrimAnalyzer + EnableAotAnalyzer + EnableSingleFileAnalyzer so
+         trim/AOT (IL2xxx/IL3xxx) issues surface at build time. CI builds with
+         TreatWarningsAsErrors=true, so these become hard build failures. -->
+    <IsAotCompatible>true</IsAotCompatible>
+
     <!-- Assembly signing (only if key file exists) -->
     <SignAssembly Condition="Exists('$(MSBuildThisFileDirectory)..\..\keys\CodeCargo.2025-05-12.snk')">true</SignAssembly>
     <AssemblyOriginatorKeyFile Condition="Exists('$(MSBuildThisFileDirectory)..\..\keys\CodeCargo.2025-05-12.snk')">$(MSBuildThisFileDirectory)..\..\keys\NatsDistributedCache.2025-05-12.snk</AssemblyOriginatorKeyFile>

--- a/src/NatsHybridCacheExtensions/packages.linux-arm64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.linux-arm64.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -175,9 +175,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.linux-arm64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.linux-arm64.lock.json
@@ -14,6 +14,12 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -166,6 +172,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.linux-x64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.linux-x64.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -175,9 +175,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.linux-x64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.linux-x64.lock.json
@@ -14,6 +14,12 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -166,6 +172,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.osx-arm64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.osx-arm64.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -175,9 +175,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.osx-arm64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.osx-arm64.lock.json
@@ -14,6 +14,12 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -166,6 +172,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.win-x64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.win-x64.lock.json
@@ -16,9 +16,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[10.0.1, )",
-        "resolved": "10.0.1",
-        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "f5VCIE7AJpd5YvzNTeMGVzQIgyE9tX+AreTYwQF+REbu+DZo/2Ae+jNSwhPEYrVz6RRkd7y8ubXjk6Nn6Ka+Cg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
@@ -175,9 +175,9 @@
       },
       "Microsoft.NET.ILLink.Tasks": {
         "type": "Direct",
-        "requested": "[8.0.22, )",
-        "resolved": "8.0.22",
-        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
+        "requested": "[8.0.29, )",
+        "resolved": "8.0.29",
+        "contentHash": "HSBTfrkIZijz8z3ybLRKB7E8rHk4QQufFwpHa9fc5CMIgRhRzdn4mBGmlyXZqaueiMPtuJcnjresGvSTfaW8Mg=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/src/NatsHybridCacheExtensions/packages.win-x64.lock.json
+++ b/src/NatsHybridCacheExtensions/packages.win-x64.lock.json
@@ -14,6 +14,12 @@
           "Microsoft.Extensions.Options": "10.0.9"
         }
       },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "ISahzLHsHY7vrwqr2p1YWZ+gsxoBRtH7gWRDK8fDUst9pp2He0GiesaqEfeX0V8QMCJM3eNEHGGpnIcPjFo2NQ=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[10.0.300, )",
@@ -166,6 +172,12 @@
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
           "Microsoft.Extensions.Options": "10.0.9"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.22, )",
+        "resolved": "8.0.22",
+        "contentHash": "MhcMithKEiyyNkD2ZfbDZPmcOdi0GheGfg8saEIIEfD/fol3iHmcV8TsZkD4ZYz5gdUuoX4YtlVySUU7Sxl9SQ=="
       },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",

--- a/test/UnitTests/Extensions/NatsExtensionsKeyValidationTests.cs
+++ b/test/UnitTests/Extensions/NatsExtensionsKeyValidationTests.cs
@@ -1,0 +1,59 @@
+using Moq;
+using NATS.Client.KeyValueStore;
+
+namespace CodeCargo.Nats.DistributedCache.UnitTests.Extensions;
+
+/// <summary>
+/// Verifies the source-generated [GeneratedRegex] key validator in <see cref="NatsExtensions"/>
+/// accepts and rejects exactly the same keys as the previous RegexOptions.Compiled implementation.
+/// TryValidateKey is private, so validation is exercised through the public TryPutWithTtlAsync entry
+/// point: a valid key passes validation and reaches the store, while an invalid key short-circuits
+/// with a NatsKVException before the store is touched.
+/// </summary>
+public class NatsExtensionsKeyValidationTests
+{
+    [Theory]
+    [InlineData("abc123")]
+    [InlineData("a-b_c.d/e=f")] // full character set: - _ . / = plus letters and digits
+    [InlineData("UPPER-lower-0-9")]
+    [InlineData("path/to/key")]
+    [InlineData("has.dots.inside")] // internal dots are allowed
+    public async Task TryPutWithTtlAsync_ValidKey_PassesValidationAndReachesStore(string key)
+    {
+        // A valid key must pass validation and proceed to the store. The mocked store throws a
+        // sentinel the moment its JetStreamContext is read (the first store member the extension
+        // touches), so observing that exact sentinel proves validation accepted the key.
+        var sentinel = new InvalidOperationException("reached-store");
+        var store = new Mock<INatsKVStore>();
+        store.SetupGet(s => s.JetStreamContext).Throws(sentinel);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await store.Object.TryPutWithTtlAsync(key, "value"));
+
+        Assert.Same(sentinel, thrown);
+    }
+
+    [Theory]
+    [InlineData("", "Key cannot be empty")]
+    [InlineData(" ", "Key cannot be empty")]
+    [InlineData(".lead", "Key cannot start or end with a period")]
+    [InlineData("trail.", "Key cannot start or end with a period")]
+    [InlineData(".", "Key cannot start or end with a period")]
+    [InlineData("has space", "Key contains invalid characters")]
+    [InlineData("bad!char", "Key contains invalid characters")]
+    [InlineData("with@sign", "Key contains invalid characters")]
+    public async Task TryPutWithTtlAsync_InvalidKey_ReturnsErrorWithoutTouchingStore(
+        string key,
+        string expectedMessage)
+    {
+        // MockBehavior.Strict fails the test on any store access, proving invalid keys are rejected
+        // before the extension touches the store.
+        var store = new Mock<INatsKVStore>(MockBehavior.Strict);
+
+        var result = await store.Object.TryPutWithTtlAsync(key, "value");
+
+        Assert.False(result.Success);
+        Assert.IsType<NatsKVException>(result.Error);
+        Assert.Equal(expectedMessage, result.Error.Message);
+    }
+}


### PR DESCRIPTION
Part of #45 (AOT / trimming compatibility). One of three independent PRs splitting that issue.

## What
- Enable `<IsAotCompatible>true</IsAotCompatible>` on the core (`NatsDistributedCache`) and hybrid (`NatsHybridCacheExtensions`) packages.
- Convert the `RegexOptions.Compiled` key-validation regex in `NatsExtensions` to a source-generated `[GeneratedRegex]` partial method (pattern semantics preserved exactly, `\A…\z` anchors and `/ = .` chars kept).
- Regenerate the NuGet lock files.
- Add unit tests for the key-validation regex accept/reject behavior.

## Notes
- With the analyzers active, **both packages build with zero IL2xxx/IL3xxx warnings** on net8.0 and net10.0 under `-p TreatWarningsAsErrors=true` — including the generic `NatsHybridCacheSerializer<T>` / `serializerRegistry.GetSerializer<T>()` path, so no `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]` forwarding was needed.
- `RegexOptions.Compiled` is not flagged by the IL analyzers, but it degrades under AOT (Reflection.Emit → interpreter fallback); the conversion is proactive hardening.
- The only lock-file delta is the SDK-implicit, build-time-only `Microsoft.NET.ILLink.Tasks` package that enabling the analyzers pulls in. It has `PrivateAssets` and never flows to package consumers. Regenerating is required because the repo enforces `RestoreLockedMode=true` + a CI drift check.

## Testing
- `dotnet build -p TreatWarningsAsErrors=true`: 0 warnings / 0 errors, net8.0 + net10.0.
- Unit tests: 122/122 pass (both TFMs). Integration tests: 78/78 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
